### PR TITLE
Add user account menu with avatar dropdown

### DIFF
--- a/content.js
+++ b/content.js
@@ -254,6 +254,18 @@
       return true;
     }
 
+    if (msg.type === 'GET_CURRENT_USER') {
+      // Fetches /wp/v2/users/me?context=edit. The nonce arrives from the
+      // popup via the same MAIN-world extraction that GET_SITE_INFO uses.
+      const ctx = detection.context;
+      const nonce = msg.nonce || null;
+      globalThis.WPRest
+        .fetchCurrentUser({ restApiRoot: ctx.restApiRoot, origin: location.origin, nonce })
+        .then((user) => sendResponse({ user }))
+        .catch(() => sendResponse({ user: null }));
+      return true;
+    }
+
     if (msg.type === 'TOGGLE_QUERY_MONITOR') {
       // QM toggles its main panel via a click on the admin-bar link, OR
       // directly via the `.qm-show` class on #query-monitor-main. The

--- a/lib/detect.js
+++ b/lib/detect.js
@@ -77,6 +77,19 @@
         // icon is configured — generic theme favicons are intentionally
         // not picked up so the popup header stays meaningful.
         siteIconUrl: null,
+        // Current user — populated from the admin bar's My Account menu
+        // when present. Avatar comes from #wp-admin-bar-user-info (the
+        // 64×64 variant), display name from .display-name, and the
+        // edit-profile link from #wp-admin-bar-edit-profile.
+        userAvatarUrl: null,
+        userDisplayName: null,
+        userEditProfileHref: null,
+        // Multisite super admin — distinct from any per-site role. Super
+        // admins frequently carry only `subscriber` in `wp_capabilities`
+        // for a given site, so a REST role lookup mislabels them. The
+        // admin bar exposes the network-admin menu only to super admins,
+        // which gives us a synchronous, accurate signal.
+        isSuperAdmin: false,
       },
     };
 
@@ -156,6 +169,40 @@
       } else if (previewLink) {
         result.context.adminBarViewHref = previewLink.href;
         result.context.postStatus = 'draft';
+      }
+
+      // Current-user info from the My Account menu. The 64×64 avatar in
+      // #wp-admin-bar-user-info is the higher-resolution variant; if it's
+      // missing (themes/plugins occasionally remove the submenu) we fall
+      // back to the inline 26×26 image on the top-level link.
+      const userInfoImg = adminBar.querySelector('#wp-admin-bar-user-info img.avatar');
+      const fallbackImg = adminBar.querySelector('#wp-admin-bar-my-account img.avatar');
+      const avatarImg = userInfoImg || fallbackImg;
+      if (avatarImg && avatarImg.getAttribute('src')) {
+        try {
+          const p = new URL(avatarImg.src).protocol;
+          if (p === 'http:' || p === 'https:' || p === 'data:') {
+            result.context.userAvatarUrl = avatarImg.src;
+          }
+        } catch (_) { /* malformed avatar URL, skip */ }
+      }
+
+      const displayNameEl = adminBar.querySelector('#wp-admin-bar-user-info .display-name')
+        || adminBar.querySelector('#wp-admin-bar-my-account .display-name');
+      if (displayNameEl) {
+        const name = (displayNameEl.textContent || '').trim();
+        if (name) result.context.userDisplayName = name;
+      }
+
+      const editProfileLink = adminBar.querySelector('#wp-admin-bar-edit-profile a[href]');
+      if (editProfileLink) result.context.userEditProfileHref = editProfileLink.href;
+
+      // WP only renders the network-admin menu group for super admins
+      // (see wp_admin_bar_my_sites_menu()). Use the wrapper id rather
+      // than the dashboard child link so we still catch sites that
+      // customize the inner items.
+      if (adminBar.querySelector('#wp-admin-bar-network-admin')) {
+        result.context.isSuperAdmin = true;
       }
 
       // Status counts. The <li> is only rendered when the user has the

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -252,6 +252,27 @@
   }
 
   /**
+   * Current user — `/wp/v2/users/me?context=edit`. Cookie auth + nonce.
+   * `edit` context is what exposes the `roles` field (default `view`
+   * context omits it); WP always allows the current user to read their
+   * own record in edit context, so any logged-in user works. Returns the
+   * user object or null on any failure (logged out, missing nonce, etc.).
+   */
+  async function fetchCurrentUser({ restApiRoot, origin, nonce, fetchImpl = fetch }) {
+    const root = normalizeRoot(restApiRoot, origin);
+    try {
+      const res = await fetchImpl(`${root}wp/v2/users/me?context=edit`, {
+        credentials: 'include',
+        headers: nonce ? { 'X-WP-Nonce': nonce } : undefined,
+      });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /**
    * Raw post content — requires the user to be able to edit the given post
    * (WP returns 401 otherwise). Returns the content string with block
    * comments intact, or null on any failure. Used by the block inspector
@@ -313,6 +334,7 @@
     fetchSiteInfo,
     fetchActiveTheme,
     fetchPluginsDetail,
+    fetchCurrentUser,
     fetchRawContent,
     findNonceInDocument,
     isSameOriginAdminUrl,

--- a/src/popup/components/DetectedView.js
+++ b/src/popup/components/DetectedView.js
@@ -4,16 +4,12 @@ import {
 	seen,
 	globe,
 	dashboard,
-	key,
-	keyboardReturn,
-	login,
 } from '@wordpress/icons';
 import { Header } from './Header';
 import { ActionRow } from './ActionRow';
 import { ToggleRow } from './ToggleRow';
 import { DevTools } from './DevTools';
 import { NewContent } from './NewContent';
-import { InlineConfirm } from './InlineConfirm';
 import { SiteInfoPanel } from './SiteInfoPanel';
 import { usePrefs } from '../hooks/usePrefs';
 import { runAction, applyAdminBarPref, requestRestEditUrl } from '../lib/actions';
@@ -45,31 +41,26 @@ export function DetectedView({ result, host }) {
 				wpVersion={ctx.generatorVersion || null}
 				loggedIn={isLoggedIn}
 				origin={origin}
+				url={url}
 				updateCount={ctx.updateCount || null}
 				commentCount={ctx.commentCount || null}
 				siteIconUrl={ctx.siteIconUrl || null}
+				userAvatarUrl={ctx.userAvatarUrl || null}
+				userDisplayName={ctx.userDisplayName || null}
+				userEditProfileHref={ctx.userEditProfileHref || null}
+				isSuperAdmin={!!ctx.isSuperAdmin}
+				logoutUrl={ctx.adminBarLogoutHref || null}
 				onOpen={openInNewTab}
 			/>
-			<Section>
-				{isLoggedIn ? (
-					isWpAdmin ? (
+			{isLoggedIn && (
+				<Section>
+					{isWpAdmin ? (
 						<WpAdminActions ctx={ctx} origin={origin} url={url} />
 					) : (
 						<FrontendLoggedInActions ctx={ctx} origin={origin} url={url} />
-					)
-				) : (
-					<LoggedOutActions origin={origin} url={url} />
-				)}
-
-				{isLoggedIn && (
-					<InlineConfirm
-						icon={login}
-						label="Log Out"
-						onConfirm={() => runAction('signout', { origin, url, logoutUrl: ctx.adminBarLogoutHref })}
-						destructive
-					/>
-				)}
-			</Section>
+					)}
+				</Section>
+			)}
 			{isLoggedIn && ctx.newContentItems?.length > 0 && (
 				<NewContent items={ctx.newContentItems} onOpen={openUrl} />
 			)}
@@ -198,25 +189,6 @@ function AdminBarSection({ ctx, origin, prefs, onToggle }) {
 					Check profile →
 				</button>
 			</div>
-		</>
-	);
-}
-
-function LoggedOutActions({ origin, url }) {
-	return (
-		<>
-			<ActionRow
-				icon={key}
-				label="Log In"
-				onClick={() => runAction('login', { origin, url })}
-				onNewTab={() => runAction('login', { origin, url, newTab: true })}
-			/>
-			<ActionRow
-				icon={keyboardReturn}
-				label="Log In, Return to Page"
-				onClick={() => runAction('login-return', { origin, url })}
-				onNewTab={() => runAction('login-return', { origin, url, newTab: true })}
-			/>
 		</>
 	);
 }

--- a/src/popup/components/DetectedView.js
+++ b/src/popup/components/DetectedView.js
@@ -4,6 +4,8 @@ import {
 	seen,
 	globe,
 	dashboard,
+	key,
+	keyboardReturn,
 } from '@wordpress/icons';
 import { Header } from './Header';
 import { ActionRow } from './ActionRow';
@@ -52,15 +54,17 @@ export function DetectedView({ result, host }) {
 				logoutUrl={ctx.adminBarLogoutHref || null}
 				onOpen={openInNewTab}
 			/>
-			{isLoggedIn && (
-				<Section>
-					{isWpAdmin ? (
+			<Section>
+				{isLoggedIn ? (
+					isWpAdmin ? (
 						<WpAdminActions ctx={ctx} origin={origin} url={url} />
 					) : (
 						<FrontendLoggedInActions ctx={ctx} origin={origin} url={url} />
-					)}
-				</Section>
-			)}
+					)
+				) : (
+					<LoggedOutActions origin={origin} url={url} />
+				)}
+			</Section>
 			{isLoggedIn && ctx.newContentItems?.length > 0 && (
 				<NewContent items={ctx.newContentItems} onOpen={openUrl} />
 			)}
@@ -164,6 +168,25 @@ function FrontendLoggedInActions({ ctx, origin, url }) {
 				onNewTab={() => runAction('admin', { origin, url, newTab: true })}
 			/>
 			<AdminBarSection ctx={ctx} origin={origin} prefs={prefs} onToggle={toggleAdminBar} />
+		</>
+	);
+}
+
+function LoggedOutActions({ origin, url }) {
+	return (
+		<>
+			<ActionRow
+				icon={key}
+				label="Log In"
+				onClick={() => runAction('login', { origin, url })}
+				onNewTab={() => runAction('login', { origin, url, newTab: true })}
+			/>
+			<ActionRow
+				icon={keyboardReturn}
+				label="Log In, Return to Page"
+				onClick={() => runAction('login-return', { origin, url })}
+				onNewTab={() => runAction('login-return', { origin, url, newTab: true })}
+			/>
 		</>
 	);
 }

--- a/src/popup/components/Header.js
+++ b/src/popup/components/Header.js
@@ -39,16 +39,17 @@ export function Header({
 					)}
 					<span className="wpd-header__hostname">{hostname}</span>
 				</h1>
-				<UserMenu
-					isLoggedIn={loggedIn}
-					avatarUrl={userAvatarUrl}
-					displayName={userDisplayName}
-					origin={origin}
-					url={url}
-					logoutUrl={logoutUrl}
-					editProfileUrl={userEditProfileHref}
-					isSuperAdmin={isSuperAdmin}
-				/>
+				{loggedIn && (
+					<UserMenu
+						avatarUrl={userAvatarUrl}
+						displayName={userDisplayName}
+						origin={origin}
+						url={url}
+						logoutUrl={logoutUrl}
+						editProfileUrl={userEditProfileHref}
+						isSuperAdmin={isSuperAdmin}
+					/>
+				)}
 			</div>
 			{showMeta && (
 				<div className="wpd-header__meta">

--- a/src/popup/components/Header.js
+++ b/src/popup/components/Header.js
@@ -2,6 +2,7 @@ import { Badge } from '@wordpress/ui';
 import { update, postComments } from '@wordpress/icons';
 import { HostBadge } from './HostBadge';
 import { StatusBadge } from './StatusBadge';
+import { UserMenu } from './UserMenu';
 
 export function Header({
 	hostname,
@@ -9,33 +10,50 @@ export function Header({
 	wpVersion = null,
 	loggedIn = false,
 	origin = null,
+	url = null,
 	updateCount = null,
 	commentCount = null,
 	siteIconUrl = null,
+	userAvatarUrl = null,
+	userDisplayName = null,
+	userEditProfileHref = null,
+	isSuperAdmin = false,
+	logoutUrl = null,
 	onOpen,
 }) {
 	const hasStatus = (updateCount && updateCount > 0) || (commentCount && commentCount > 0);
-	const showMeta = host || wpVersion || loggedIn;
+	const showMeta = host || wpVersion;
 	return (
 		<header className="wpd-header">
-			<h1 className="wpd-header__title" title={hostname}>
-				{siteIconUrl && (
-					<img
-						className="wpd-header__site-icon"
-						src={siteIconUrl}
-						alt=""
-						loading="lazy"
-						referrerPolicy="no-referrer"
-						onError={(e) => { e.currentTarget.style.display = 'none'; }}
-					/>
-				)}
-				<span className="wpd-header__hostname">{hostname}</span>
-			</h1>
+			<div className="wpd-header__top">
+				<h1 className="wpd-header__title" title={hostname}>
+					{siteIconUrl && (
+						<img
+							className="wpd-header__site-icon"
+							src={siteIconUrl}
+							alt=""
+							loading="lazy"
+							referrerPolicy="no-referrer"
+							onError={(e) => { e.currentTarget.style.display = 'none'; }}
+						/>
+					)}
+					<span className="wpd-header__hostname">{hostname}</span>
+				</h1>
+				<UserMenu
+					isLoggedIn={loggedIn}
+					avatarUrl={userAvatarUrl}
+					displayName={userDisplayName}
+					origin={origin}
+					url={url}
+					logoutUrl={logoutUrl}
+					editProfileUrl={userEditProfileHref}
+					isSuperAdmin={isSuperAdmin}
+				/>
+			</div>
 			{showMeta && (
 				<div className="wpd-header__meta">
 					{host && <HostBadge host={host} />}
 					{wpVersion && <Badge intent="none">WordPress {wpVersion}</Badge>}
-					{loggedIn && <Badge intent="informational">Logged in</Badge>}
 				</div>
 			)}
 			{hasStatus && origin && (

--- a/src/popup/components/UserMenu.js
+++ b/src/popup/components/UserMenu.js
@@ -1,0 +1,194 @@
+import { useEffect, useRef, useState } from 'react';
+import { Icon, Popover, VisuallyHidden } from '@wordpress/ui';
+import { people, key, keyboardReturn, login, cog } from '@wordpress/icons';
+import { runAction, requestCurrentUser } from '../lib/actions';
+
+/**
+ * Circular avatar button in the header's top-right. Opens a small popover
+ * with account actions: profile + account settings + log out when signed
+ * in, or login shortcuts when signed out.
+ *
+ * Built on @wordpress/ui's Popover primitives — they own positioning,
+ * focus management, click-outside, and Escape handling. Each non-
+ * destructive menu item is a Popover.Close so activation auto-dismisses;
+ * the destructive logout uses a regular button so its two-click confirm
+ * can live inside the open popover.
+ */
+export function UserMenu({ isLoggedIn, avatarUrl, displayName, origin, url, logoutUrl, editProfileUrl, isSuperAdmin = false }) {
+	const [open, setOpen] = useState(false);
+	const [confirmingLogout, setConfirmingLogout] = useState(false);
+	const [restRole, setRestRole] = useState(null);
+	const confirmTimerRef = useRef(null);
+
+	// Pre-fetch the role on mount so the dropdown opens with the label
+	// already in place. Skipped for super admins (the DOM-derived "Super
+	// Admin" badge takes priority and a per-site role would be misleading)
+	// and when logged out.
+	useEffect(() => {
+		if (!isLoggedIn || isSuperAdmin) return;
+		let cancelled = false;
+		requestCurrentUser().then((user) => {
+			if (cancelled) return;
+			const slug = Array.isArray(user?.roles) ? user.roles[0] : null;
+			if (slug) setRestRole(formatRoleSlug(slug));
+		});
+		return () => { cancelled = true; };
+	}, [isLoggedIn, isSuperAdmin]);
+
+	useEffect(() => {
+		if (!open) {
+			setConfirmingLogout(false);
+			clearTimeout(confirmTimerRef.current);
+		}
+	}, [open]);
+
+	useEffect(() => () => clearTimeout(confirmTimerRef.current), []);
+
+	// Super admin wins. On multisite a super admin's per-site role is
+	// commonly just 'subscriber', so REST would mislabel them.
+	const roleLabel = isSuperAdmin ? 'Super Admin' : restRole;
+
+	const profileUrl = editProfileUrl || `${origin}/wp-admin/profile.php`;
+	const buttonLabel = isLoggedIn
+		? `Account menu${displayName ? ` for ${displayName}` : ''}`
+		: 'Account menu';
+
+	const handleLogoutClick = () => {
+		if (!confirmingLogout) {
+			setConfirmingLogout(true);
+			clearTimeout(confirmTimerRef.current);
+			confirmTimerRef.current = setTimeout(() => setConfirmingLogout(false), 4000);
+			return;
+		}
+		clearTimeout(confirmTimerRef.current);
+		setOpen(false);
+		runAction('signout', { origin, url, logoutUrl });
+	};
+
+	return (
+		<Popover.Root open={open} onOpenChange={setOpen}>
+			<Popover.Trigger
+				className="wpd-user-menu__button"
+				aria-label={buttonLabel}
+				title={displayName || buttonLabel}
+			>
+				{isLoggedIn && avatarUrl ? (
+					<img
+						className="wpd-user-menu__avatar"
+						src={avatarUrl}
+						alt=""
+						referrerPolicy="no-referrer"
+						onError={(e) => {
+							e.currentTarget.style.display = 'none';
+						}}
+					/>
+				) : (
+					<span className="wpd-user-menu__avatar wpd-user-menu__avatar--placeholder" aria-hidden="true">
+						<Icon icon={people} size={16} />
+					</span>
+				)}
+			</Popover.Trigger>
+			<Popover.Popup
+				className="wpd-user-menu__positioner"
+				variant="unstyled"
+				align="end"
+				sideOffset={8}
+			>
+				<VisuallyHidden>
+					<Popover.Title>Account menu</Popover.Title>
+				</VisuallyHidden>
+				<div className="wpd-user-menu__dropdown" role="menu">
+				{isLoggedIn && displayName && (
+					<div className="wpd-user-menu__header">
+						<span className="wpd-user-menu__name" title={displayName}>{displayName}</span>
+						{roleLabel && (
+							<span className="wpd-user-menu__role" title={roleLabel}>{roleLabel}</span>
+						)}
+					</div>
+				)}
+				{isLoggedIn ? (
+					<>
+						<MenuLink
+							icon={people}
+							label="Profile"
+							onClick={() => {
+								chrome.tabs.update({ url: profileUrl });
+								window.close();
+							}}
+						/>
+						<MenuLink
+							icon={cog}
+							label="Account Settings"
+							onClick={() => {
+								chrome.tabs.update({ url: `${origin}/wp-admin/profile.php` });
+								window.close();
+							}}
+						/>
+						<button
+							type="button"
+							role="menuitem"
+							className={`wpd-user-menu__item wpd-user-menu__item--destructive ${confirmingLogout ? 'is-active' : ''}`}
+							onClick={handleLogoutClick}
+						>
+							<span className="wpd-user-menu__item-icon" aria-hidden="true">
+								<Icon icon={login} size={16} />
+							</span>
+							<span className="wpd-user-menu__item-label">
+								{confirmingLogout ? 'Click again to confirm' : 'Log Out'}
+							</span>
+						</button>
+					</>
+				) : (
+					<>
+						<MenuLink
+							icon={key}
+							label="Log In"
+							onClick={() => runAction('login', { origin, url })}
+						/>
+						<MenuLink
+							icon={keyboardReturn}
+							label="Log In, Return to Page"
+							onClick={() => runAction('login-return', { origin, url })}
+						/>
+					</>
+				)}
+				</div>
+			</Popover.Popup>
+		</Popover.Root>
+	);
+}
+
+/**
+ * Menu item that closes the popover on activation. Popover.Close handles the
+ * dismissal; the onClick runs after the popover is told to close so the
+ * subsequent chrome.tabs / window.close calls don't race the popover's own
+ * cleanup.
+ */
+/**
+ * Title-cases a WP role slug for display. WP's own `translate_user_role()`
+ * runs slugs through i18n; here we just normalize separators and capitalize.
+ * "administrator" → "Administrator", "shop_manager" → "Shop Manager".
+ */
+function formatRoleSlug(slug) {
+	if (typeof slug !== 'string' || !slug) return null;
+	return slug
+		.split(/[-_]+/)
+		.filter(Boolean)
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+		.join(' ');
+}
+
+function MenuLink({ icon, label, onClick }) {
+	return (
+		<Popover.Close
+			role="menuitem"
+			className="wpd-user-menu__item"
+			onClick={onClick}
+		>
+			<span className="wpd-user-menu__item-icon" aria-hidden="true">
+				<Icon icon={icon} size={16} />
+			</span>
+			<span className="wpd-user-menu__item-label">{label}</span>
+		</Popover.Close>
+	);
+}

--- a/src/popup/components/UserMenu.js
+++ b/src/popup/components/UserMenu.js
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { Icon, Popover, VisuallyHidden } from '@wordpress/ui';
-import { people, key, keyboardReturn, login, cog } from '@wordpress/icons';
+import { people, login, image } from '@wordpress/icons';
 import { runAction, requestCurrentUser } from '../lib/actions';
 
 /**
  * Circular avatar button in the header's top-right. Opens a small popover
- * with account actions: profile + account settings + log out when signed
- * in, or login shortcuts when signed out.
+ * with Profile, Account Settings, and Log Out. Rendered only when signed
+ * in — the caller gates on login state.
  *
  * Built on @wordpress/ui's Popover primitives — they own positioning,
  * focus management, click-outside, and Escape handling. Each non-
@@ -14,26 +14,25 @@ import { runAction, requestCurrentUser } from '../lib/actions';
  * the destructive logout uses a regular button so its two-click confirm
  * can live inside the open popover.
  */
-export function UserMenu({ isLoggedIn, avatarUrl, displayName, origin, url, logoutUrl, editProfileUrl, isSuperAdmin = false }) {
+export function UserMenu({ avatarUrl, displayName, origin, url, logoutUrl, editProfileUrl, isSuperAdmin = false }) {
 	const [open, setOpen] = useState(false);
 	const [confirmingLogout, setConfirmingLogout] = useState(false);
 	const [restRole, setRestRole] = useState(null);
 	const confirmTimerRef = useRef(null);
 
 	// Pre-fetch the role on mount so the dropdown opens with the label
-	// already in place. Skipped for super admins (the DOM-derived "Super
-	// Admin" badge takes priority and a per-site role would be misleading)
-	// and when logged out.
+	// already in place. Skipped for super admins — the DOM-derived "Super
+	// Admin" badge takes priority and a per-site role would be misleading.
 	useEffect(() => {
-		if (!isLoggedIn || isSuperAdmin) return;
+		if (isSuperAdmin) return;
 		let cancelled = false;
 		requestCurrentUser().then((user) => {
 			if (cancelled) return;
-			const slug = Array.isArray(user?.roles) ? user.roles[0] : null;
-			if (slug) setRestRole(formatRoleSlug(slug));
+			const label = roleLabelFromUser(user);
+			if (label) setRestRole(label);
 		});
 		return () => { cancelled = true; };
-	}, [isLoggedIn, isSuperAdmin]);
+	}, [isSuperAdmin]);
 
 	useEffect(() => {
 		if (!open) {
@@ -49,9 +48,12 @@ export function UserMenu({ isLoggedIn, avatarUrl, displayName, origin, url, logo
 	const roleLabel = isSuperAdmin ? 'Super Admin' : restRole;
 
 	const profileUrl = editProfileUrl || `${origin}/wp-admin/profile.php`;
-	const buttonLabel = isLoggedIn
-		? `Account menu${displayName ? ` for ${displayName}` : ''}`
-		: 'Account menu';
+	const buttonLabel = displayName ? `Account menu for ${displayName}` : 'Account menu';
+	// Admin bar avatars from gravatar.com carry the user's hash in the path.
+	// Custom-avatar plugins (User Profile Picture, etc.) point at an upload
+	// on the site's own host and won't match — we hide the menu item then.
+	const gravatarHash = extractGravatarHash(avatarUrl);
+	const gravatarProfileUrl = gravatarHash ? `https://gravatar.com/${gravatarHash}` : null;
 
 	const handleLogoutClick = () => {
 		if (!confirmingLogout) {
@@ -72,7 +74,7 @@ export function UserMenu({ isLoggedIn, avatarUrl, displayName, origin, url, logo
 				aria-label={buttonLabel}
 				title={displayName || buttonLabel}
 			>
-				{isLoggedIn && avatarUrl ? (
+				{avatarUrl ? (
 					<img
 						className="wpd-user-menu__avatar"
 						src={avatarUrl}
@@ -98,60 +100,45 @@ export function UserMenu({ isLoggedIn, avatarUrl, displayName, origin, url, logo
 					<Popover.Title>Account menu</Popover.Title>
 				</VisuallyHidden>
 				<div className="wpd-user-menu__dropdown" role="menu">
-				{isLoggedIn && displayName && (
-					<div className="wpd-user-menu__header">
-						<span className="wpd-user-menu__name" title={displayName}>{displayName}</span>
-						{roleLabel && (
-							<span className="wpd-user-menu__role" title={roleLabel}>{roleLabel}</span>
-						)}
-					</div>
-				)}
-				{isLoggedIn ? (
-					<>
+					{displayName && (
+						<div className="wpd-user-menu__header">
+							<span className="wpd-user-menu__name" title={displayName}>{displayName}</span>
+							{roleLabel && (
+								<span className="wpd-user-menu__role" title={roleLabel}>{roleLabel}</span>
+							)}
+						</div>
+					)}
+					<MenuLink
+						icon={people}
+						label="Profile"
+						onClick={() => {
+							chrome.tabs.update({ url: profileUrl });
+							window.close();
+						}}
+					/>
+					{gravatarProfileUrl && (
 						<MenuLink
-							icon={people}
-							label="Profile"
+							icon={image}
+							label="Gravatar"
 							onClick={() => {
-								chrome.tabs.update({ url: profileUrl });
+								chrome.tabs.create({ url: gravatarProfileUrl });
 								window.close();
 							}}
 						/>
-						<MenuLink
-							icon={cog}
-							label="Account Settings"
-							onClick={() => {
-								chrome.tabs.update({ url: `${origin}/wp-admin/profile.php` });
-								window.close();
-							}}
-						/>
-						<button
-							type="button"
-							role="menuitem"
-							className={`wpd-user-menu__item wpd-user-menu__item--destructive ${confirmingLogout ? 'is-active' : ''}`}
-							onClick={handleLogoutClick}
-						>
-							<span className="wpd-user-menu__item-icon" aria-hidden="true">
-								<Icon icon={login} size={16} />
-							</span>
-							<span className="wpd-user-menu__item-label">
-								{confirmingLogout ? 'Click again to confirm' : 'Log Out'}
-							</span>
-						</button>
-					</>
-				) : (
-					<>
-						<MenuLink
-							icon={key}
-							label="Log In"
-							onClick={() => runAction('login', { origin, url })}
-						/>
-						<MenuLink
-							icon={keyboardReturn}
-							label="Log In, Return to Page"
-							onClick={() => runAction('login-return', { origin, url })}
-						/>
-					</>
-				)}
+					)}
+					<button
+						type="button"
+						role="menuitem"
+						className={`wpd-user-menu__item wpd-user-menu__item--destructive ${confirmingLogout ? 'is-active' : ''}`}
+						onClick={handleLogoutClick}
+					>
+						<span className="wpd-user-menu__item-icon" aria-hidden="true">
+							<Icon icon={login} size={16} />
+						</span>
+						<span className="wpd-user-menu__item-label">
+							{confirmingLogout ? 'Click again to confirm' : 'Log Out'}
+						</span>
+					</button>
 				</div>
 			</Popover.Popup>
 		</Popover.Root>
@@ -159,11 +146,76 @@ export function UserMenu({ isLoggedIn, avatarUrl, displayName, origin, url, logo
 }
 
 /**
- * Menu item that closes the popover on activation. Popover.Close handles the
- * dismissal; the onClick runs after the popover is told to close so the
- * subsequent chrome.tabs / window.close calls don't race the popover's own
- * cleanup.
+ * Pick a role label for the current user from a `/users/me?context=edit`
+ * response. WP doesn't expose role seniority via REST, so we use two
+ * signals in order:
+ *
+ *   1. **Role slug** — `roles[]` preserves `wp_capabilities` insertion
+ *      order, so `roles[0]` mislabels anyone added as subscriber and
+ *      later elevated. Instead, prefer the highest-rank built-in role
+ *      they have; if their only built-in is subscriber, prefer a
+ *      non-subscriber custom role (e.g. shop_manager → "Shop Manager");
+ *      otherwise return the first listed slug.
+ *
+ *   2. **Capability fallback** — used when `roles[]` is missing or
+ *      empty, which happens on installs where a hardening plugin or
+ *      `rest_prepare_user` filter strips the roles field but leaves
+ *      `capabilities` intact. Maps the highest-privilege built-in cap
+ *      the user has to its corresponding role label.
+ *
+ * Returns null only if both signals are absent.
  */
+const BUILTIN_PRIORITY = ['administrator', 'editor', 'author', 'contributor', 'subscriber'];
+
+const ROLE_BY_CAPABILITY = [
+	['manage_options',    'Administrator'],
+	['edit_others_posts', 'Editor'],
+	['publish_posts',     'Author'],
+	['edit_posts',        'Contributor'],
+];
+
+function roleLabelFromUser(user) {
+	if (!user || typeof user !== 'object') return null;
+
+	const roles = Array.isArray(user.roles) ? user.roles : [];
+	if (roles.length > 0) {
+		for (const known of BUILTIN_PRIORITY) {
+			if (!roles.includes(known)) continue;
+			if (known === 'subscriber') {
+				const custom = roles.find((r) => !BUILTIN_PRIORITY.includes(r));
+				if (custom) return formatRoleSlug(custom);
+			}
+			return formatRoleSlug(known);
+		}
+		return formatRoleSlug(roles[0]);
+	}
+
+	const caps = user.capabilities || {};
+	for (const [cap, label] of ROLE_BY_CAPABILITY) {
+		if (caps[cap]) return label;
+	}
+	return null;
+}
+
+/**
+ * Pulls the Gravatar hash out of an admin-bar avatar URL. Validates by
+ * URL-parsing and checking hostname (vs a substring match on the raw
+ * string) so a hostile page can't surface a misleading Gravatar item
+ * by embedding `.gravatar.com/avatar/{hex}` in a non-gravatar URL or
+ * in a data: payload — `detect.js` accepts data: avatars by design.
+ */
+function extractGravatarHash(avatarUrl) {
+	if (typeof avatarUrl !== 'string') return null;
+	try {
+		const u = new URL(avatarUrl);
+		if (u.hostname !== 'gravatar.com' && !u.hostname.endsWith('.gravatar.com')) return null;
+		const m = u.pathname.match(/^\/avatar\/([a-f0-9]+)/i);
+		return m ? m[1] : null;
+	} catch (_) {
+		return null;
+	}
+}
+
 /**
  * Title-cases a WP role slug for display. WP's own `translate_user_role()`
  * runs slugs through i18n; here we just normalize separators and capitalize.
@@ -178,6 +230,12 @@ function formatRoleSlug(slug) {
 		.join(' ');
 }
 
+/**
+ * Menu item that closes the popover on activation. Popover.Close handles the
+ * dismissal; the onClick runs after the popover is told to close so the
+ * subsequent chrome.tabs / window.close calls don't race the popover's own
+ * cleanup.
+ */
 function MenuLink({ icon, label, onClick }) {
 	return (
 		<Popover.Close

--- a/src/popup/lib/actions.js
+++ b/src/popup/lib/actions.js
@@ -158,61 +158,76 @@ export async function requestRestEditUrl() {
 	}
 }
 
+/**
+ * Resolves a usable WP REST nonce for the active tab. Tries the live page
+ * first (MAIN-world script reads `wpApiSettings` / `_wpApiSettings` / inline
+ * config / data-* attributes), then falls back to fetching `wp-admin/profile.php`
+ * — admin pages reliably enqueue `wp-api` so the inline config object with
+ * the nonce is in the response. Returns the nonce string or null.
+ *
+ * Returns { nonce, tab } so callers can reuse the tab handle without
+ * re-querying.
+ */
+async function resolveRestNonce() {
+	const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+	let nonce = null;
+	try {
+		const [out] = await chrome.scripting.executeScript({
+			target: { tabId: tab.id },
+			world: 'MAIN',
+			func: () => {
+				if (window.wpApiSettings?.nonce) return window.wpApiSettings.nonce;
+				if (window._wpApiSettings?.nonce) return window._wpApiSettings.nonce;
+				if (window.wp?.apiFetch?.nonceMiddleware?.nonce) return window.wp.apiFetch.nonceMiddleware.nonce;
+				for (const s of document.querySelectorAll('script:not([src])')) {
+					const t = s.textContent || '';
+					const m = t.match(/(?:wpApiSettings|_wpApiSettings)\s*=\s*\{[^}]*"nonce"\s*:\s*"([a-f0-9]+)"/)
+						|| t.match(/wp\.api\.fetch\.use\(\s*wp\.api\.fetch\.createNonceMiddleware\(\s*"([a-f0-9]+)"/);
+					if (m) return m[1];
+				}
+				const el = document.querySelector('[data-rest-nonce], [data-wp-nonce], [data-nonce]');
+				return el?.getAttribute('data-rest-nonce')
+					|| el?.getAttribute('data-wp-nonce')
+					|| el?.getAttribute('data-nonce')
+					|| null;
+			},
+		});
+		nonce = out?.result || null;
+	} catch (_) { /* page disallows scripting */ }
+
+	if (!nonce) {
+		try {
+			const origin = new URL(tab.url).origin;
+			const res = await fetch(`${origin}/wp-admin/profile.php`, {
+				credentials: 'include',
+				redirect: 'follow',
+			});
+			if (res.ok) {
+				const html = await res.text();
+				const m = html.match(/(?:wpApiSettings|_wpApiSettings)\s*=\s*\{[^}]*"nonce"\s*:\s*"([a-f0-9]+)"/);
+				if (m) nonce = m[1];
+			}
+		} catch (_) { /* admin fetch failed — give up, will pass null */ }
+	}
+
+	return { tab, nonce };
+}
+
 export async function requestSiteInfo() {
 	try {
-		const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-		// WP's authenticated REST endpoints require X-WP-Nonce even with
-		// cookies. The nonce lives in several places depending on which
-		// scripts WP enqueued on the page; we look in all of them. Has to
-		// run in MAIN world — content scripts can't see page globals.
-		let nonce = null;
-		try {
-			const [out] = await chrome.scripting.executeScript({
-				target: { tabId: tab.id },
-				world: 'MAIN',
-				func: () => {
-					if (window.wpApiSettings?.nonce) return window.wpApiSettings.nonce;
-					if (window._wpApiSettings?.nonce) return window._wpApiSettings.nonce;
-					if (window.wp?.apiFetch?.nonceMiddleware?.nonce) return window.wp.apiFetch.nonceMiddleware.nonce;
-					// Inline script content — many WP setups print the nonce
-					// in a script tag without exposing it on a global.
-					for (const s of document.querySelectorAll('script:not([src])')) {
-						const t = s.textContent || '';
-						const m = t.match(/(?:wpApiSettings|_wpApiSettings)\s*=\s*\{[^}]*"nonce"\s*:\s*"([a-f0-9]+)"/)
-							|| t.match(/wp\.api\.fetch\.use\(\s*wp\.api\.fetch\.createNonceMiddleware\(\s*"([a-f0-9]+)"/);
-						if (m) return m[1];
-					}
-					// data-* attribute scan — Gutenberg + some plugins emit
-					// `data-rest-nonce`/`data-wp-nonce` on root elements.
-					const el = document.querySelector('[data-rest-nonce], [data-wp-nonce], [data-nonce]');
-					return el?.getAttribute('data-rest-nonce')
-						|| el?.getAttribute('data-wp-nonce')
-						|| el?.getAttribute('data-nonce')
-						|| null;
-				},
-			});
-			nonce = out?.result || null;
-		} catch (_) { /* page disallows scripting */ }
-
-		// If the current page didn't expose a nonce, fetch /wp-admin/profile.php
-		// — admin pages reliably enqueue wp-api so the inline script with the
-		// nonce is in the response. Lighter than the full dashboard.
-		if (!nonce) {
-			try {
-				const origin = new URL(tab.url).origin;
-				const res = await fetch(`${origin}/wp-admin/profile.php`, {
-					credentials: 'include',
-					redirect: 'follow',
-				});
-				if (res.ok) {
-					const html = await res.text();
-					const m = html.match(/(?:wpApiSettings|_wpApiSettings)\s*=\s*\{[^}]*"nonce"\s*:\s*"([a-f0-9]+)"/);
-					if (m) nonce = m[1];
-				}
-			} catch (_) { /* admin fetch failed — give up, will pass null */ }
-		}
+		const { tab, nonce } = await resolveRestNonce();
 		const res = await chrome.tabs.sendMessage(tab.id, { type: 'GET_SITE_INFO', nonce });
 		return res || null;
+	} catch (_) {
+		return null;
+	}
+}
+
+export async function requestCurrentUser() {
+	try {
+		const { tab, nonce } = await resolveRestNonce();
+		const res = await chrome.tabs.sendMessage(tab.id, { type: 'GET_CURRENT_USER', nonce });
+		return res?.user || null;
 	} catch (_) {
 		return null;
 	}

--- a/src/popup/popup.scss
+++ b/src/popup/popup.scss
@@ -103,10 +103,21 @@ body {
 	background: var(--wpd-surface);
 }
 
+/* Top row holds the title and the trailing avatar/user menu. Aligned so the
+ * avatar's vertical center matches the first line of the hostname text. */
+.wpd-header__top {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	min-width: 0;
+}
+
 .wpd-header__title {
 	display: flex;
 	align-items: center;
 	gap: 8px;
+	flex: 1;
+	min-width: 0;
 	font-family: var(--wpds-typography-font-family-body, -apple-system, system-ui, sans-serif);
 	font-size: 19px;
 	font-weight: 600;
@@ -137,6 +148,179 @@ body {
 	flex-wrap: wrap;
 	gap: 6px;
 	align-items: center;
+}
+
+/* User menu — circular bordered avatar trigger + Popover-positioned dropdown.
+ * Positioning, focus management, and dismissal come from @wordpress/ui's
+ * Popover primitives; we only style the trigger and the popup contents. */
+
+.wpd-user-menu__button {
+	display: grid;
+	place-items: center;
+	width: 32px;
+	height: 32px;
+	padding: 0;
+	border: 1px solid var(--wpd-border-strong);
+	border-radius: 50%;
+	background: var(--wpd-surface);
+	color: var(--wpd-ink-dim);
+	cursor: pointer;
+	overflow: hidden;
+	flex-shrink: 0;
+	transition: border-color 0.12s, box-shadow 0.12s;
+
+	&:hover {
+		border-color: var(--wpd-accent);
+	}
+
+	&:focus-visible {
+		outline: none;
+		border-color: var(--wpd-accent);
+		box-shadow: 0 0 0 2px var(--wpd-bg), 0 0 0 4px var(--wpd-accent);
+	}
+
+	&[aria-expanded="true"],
+	&[data-popup-open] {
+		border-color: var(--wpd-accent);
+	}
+}
+
+.wpd-user-menu__avatar {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	border-radius: 50%;
+}
+
+.wpd-user-menu__avatar--placeholder {
+	display: grid;
+	place-items: center;
+	background: var(--wpd-hover);
+	color: var(--wpd-ink-dim);
+
+	svg {
+		width: 16px;
+		height: 16px;
+		fill: currentColor;
+	}
+}
+
+/* Popover.Popup (variant="unstyled"): the `className` prop is forwarded to
+ * the floating positioner, not the popup itself, so we only set z-index
+ * there. The visible surface is the wrapper div we render as the popup's
+ * single child (`.wpd-user-menu__dropdown`). */
+.wpd-user-menu__positioner {
+	z-index: 100;
+}
+
+.wpd-user-menu__dropdown {
+	min-width: 200px;
+	padding: 6px;
+	background: var(--wpd-surface);
+	border: 1px solid var(--wpd-border);
+	border-radius: var(--wpd-radius);
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	color: var(--wpd-ink);
+	font-family: var(--wpds-typography-font-family-body, -apple-system, system-ui, sans-serif);
+	font-size: 13px;
+}
+
+.wpd-user-menu__header {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	padding: 6px 8px 8px;
+	margin-bottom: 2px;
+	border-bottom: 1px solid var(--wpd-border);
+}
+
+.wpd-user-menu__name {
+	display: block;
+	font-size: 12px;
+	font-weight: 600;
+	color: var(--wpd-ink);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wpd-user-menu__role {
+	display: block;
+	font-size: 11px;
+	font-weight: 400;
+	color: var(--wpd-ink-dim);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wpd-user-menu__item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	width: 100%;
+	padding: 8px 10px;
+	border: 0;
+	border-radius: var(--wpd-radius-sm);
+	background: transparent;
+	color: var(--wpd-ink);
+	font: inherit;
+	font-size: 12.5px;
+	text-align: left;
+	cursor: pointer;
+	transition: background-color 0.1s, color 0.1s;
+
+	&:hover {
+		background: var(--wpd-hover);
+	}
+
+	&:focus-visible {
+		outline: 2px solid var(--wpd-accent);
+		outline-offset: -2px;
+	}
+}
+
+.wpd-user-menu__item-icon {
+	display: inline-grid;
+	place-items: center;
+	width: 16px;
+	height: 16px;
+	flex-shrink: 0;
+	color: var(--wpd-ink-dim);
+
+	svg {
+		width: 16px;
+		height: 16px;
+		fill: currentColor;
+	}
+}
+
+.wpd-user-menu__item-label {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.wpd-user-menu__item--destructive {
+	color: var(--wpds-color-fg-content-error, #c53030);
+
+	.wpd-user-menu__item-icon {
+		color: inherit;
+	}
+
+	&:hover {
+		background: var(--wpds-color-bg-surface-error-weak, rgba(197, 48, 48, 0.08));
+	}
+
+	&.is-active {
+		background: var(--wpds-color-bg-interactive-error, #c53030);
+		color: #fff;
+	}
 }
 
 /* Sections ============================================================== */

--- a/src/popup/preview.js
+++ b/src/popup/preview.js
@@ -21,13 +21,21 @@ window.WPHost = {
 };
 
 // Minimal chrome.* shim so usePrefs / useEffect-driven handlers don't crash.
+// sendMessage returns a canned current-user response so the UserMenu role
+// line renders in the dev preview without a real WP backend.
 window.chrome = {
 	tabs: {
 		query: async () => [{ id: 1, url: 'https://example.test/' }],
-		sendMessage: async () => ({}),
+		sendMessage: async (_tabId, msg) => {
+			if (msg?.type === 'GET_CURRENT_USER') {
+				return { user: { id: 1, name: 'Jane Doe', roles: ['administrator'] } };
+			}
+			return {};
+		},
 	},
 	runtime: { sendMessage: async () => null },
 	storage: { local: { get: async () => ({}), set: async () => {} } },
+	scripting: { executeScript: async () => [{ result: 'fake-nonce' }] },
 };
 
 const fixtures = [
@@ -52,6 +60,11 @@ const fixtures = [
 							updateCount: 3,
 							commentCount: 2,
 							hasQueryMonitor: true,
+							userAvatarUrl: 'https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=mp&s=64',
+							userDisplayName: 'Jane Doe',
+							userEditProfileHref: 'https://myblog.test/wp-admin/profile.php',
+							isSuperAdmin: true,
+							adminBarLogoutHref: 'https://myblog.test/wp-login.php?action=logout&_wpnonce=abc',
 							newContentItems: [
 								{ id: 'post', label: 'Post', href: 'https://myblog.test/wp-admin/post-new.php' },
 								{ id: 'page', label: 'Page', href: 'https://myblog.test/wp-admin/post-new.php?post_type=page' },
@@ -84,6 +97,10 @@ const fixtures = [
 							postStatus: 'publish',
 							adminBarViewHref: 'https://myblog.test/hello-world/',
 							generatorVersion: '6.4.2',
+							userAvatarUrl: 'https://secure.gravatar.com/avatar/00000000000000000000000000000000?d=mp&s=64',
+							userDisplayName: 'Jane Doe',
+							userEditProfileHref: 'https://myblog.test/wp-admin/profile.php',
+							adminBarLogoutHref: 'https://myblog.test/wp-login.php?action=logout&_wpnonce=abc',
 						},
 					},
 				}}

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -554,6 +554,155 @@ async function main() {
       'data: scheme accepted');
   }
 
+  // --- 21. fetchCurrentUser hits /users/me with context=edit + nonce ----
+  {
+    console.log('\n[21] fetchCurrentUser — URL, headers, response shape');
+    const dom = new JSDOM(`<html><body></body></html>`);
+    const ctx = loadModules(dom);
+
+    let capturedUrl = null;
+    let capturedHeaders = null;
+    const mockFetch = async (url, options) => {
+      capturedUrl = url;
+      capturedHeaders = options && options.headers;
+      return {
+        ok: true,
+        async json() { return { id: 1, name: 'Jane', roles: ['administrator'] }; },
+      };
+    };
+
+    const user = await ctx.WPRest.fetchCurrentUser({
+      restApiRoot: 'https://example.com/wp-json/',
+      origin: 'https://example.com',
+      nonce: 'deadbeef',
+      fetchImpl: mockFetch,
+    });
+    assert(capturedUrl === 'https://example.com/wp-json/wp/v2/users/me?context=edit',
+      'hits /wp/v2/users/me with context=edit');
+    assert(capturedHeaders && capturedHeaders['X-WP-Nonce'] === 'deadbeef',
+      'X-WP-Nonce header forwarded');
+    assert(user && Array.isArray(user.roles) && user.roles[0] === 'administrator',
+      'response JSON returned verbatim');
+
+    // Non-2xx → null.
+    const nullUser = await ctx.WPRest.fetchCurrentUser({
+      restApiRoot: 'https://example.com/wp-json/',
+      origin: 'https://example.com',
+      fetchImpl: async () => ({ ok: false }),
+    });
+    assert(nullUser === null, '401 response yields null');
+  }
+
+  // --- 20. User info from admin bar -------------------------------------
+  // Avatar URL, display name, and edit-profile href come from the
+  // My Account / User Info menu items. Drives the popup's user menu.
+  {
+    console.log('\n[20] User info extracted from admin bar');
+    const dom = new JSDOM(`
+      <html><body class="logged-in admin-bar">
+        <div id="wpadminbar">
+          <ul id="wp-admin-bar-top-secondary">
+            <li id="wp-admin-bar-my-account">
+              <a class="ab-item" href="https://example.com/wp-admin/profile.php">
+                Howdy, <span class="display-name">Jane</span>
+                <img alt="" src="https://secure.gravatar.com/avatar/abc?s=26" class="avatar avatar-26 photo">
+              </a>
+              <div class="ab-sub-wrapper">
+                <ul id="wp-admin-bar-user-actions" class="ab-submenu">
+                  <li id="wp-admin-bar-user-info">
+                    <a class="ab-item" href="https://example.com/wp-admin/profile.php">
+                      <img alt="" src="https://secure.gravatar.com/avatar/abc?s=64" class="avatar avatar-64 photo">
+                      <span class="display-name">Jane Doe</span>
+                    </a>
+                  </li>
+                  <li id="wp-admin-bar-edit-profile">
+                    <a class="ab-item" href="https://example.com/wp-admin/profile.php">Edit Profile</a>
+                  </li>
+                  <li id="wp-admin-bar-logout">
+                    <a class="ab-item" href="https://example.com/wp-login.php?action=logout&_wpnonce=abc">Log Out</a>
+                  </li>
+                </ul>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </body></html>
+    `);
+    const ctx = loadModules(dom);
+    const det = ctx.WPDetect.detectWordPress(ctx.document, { origin: 'https://example.com' });
+    assert(det.context.userAvatarUrl === 'https://secure.gravatar.com/avatar/abc?s=64',
+      '64×64 avatar (from user-info submenu) wins over 26×26 top-level');
+    assert(det.context.userDisplayName === 'Jane Doe',
+      'displayName picked up from user-info submenu');
+    assert(det.context.userEditProfileHref === 'https://example.com/wp-admin/profile.php',
+      'edit-profile href captured');
+
+    // Top-level fallback when the submenu is missing.
+    const dom2 = new JSDOM(`
+      <html><body class="logged-in admin-bar">
+        <div id="wpadminbar">
+          <li id="wp-admin-bar-my-account">
+            <a class="ab-item" href="https://example.com/wp-admin/profile.php">
+              <span class="display-name">Solo</span>
+              <img alt="" src="https://example.com/avatar.png" class="avatar">
+            </a>
+          </li>
+        </div>
+      </body></html>
+    `);
+    const ctx2 = loadModules(dom2);
+    const det2 = ctx2.WPDetect.detectWordPress(ctx2.document, { origin: 'https://example.com' });
+    assert(det2.context.userAvatarUrl === 'https://example.com/avatar.png',
+      'falls back to top-level avatar when user-info submenu absent');
+    assert(det2.context.userDisplayName === 'Solo', 'display-name from top-level link');
+    assert(det2.context.userEditProfileHref === null, 'no edit-profile href when submenu missing');
+
+    // javascript: URLs in the avatar src must be rejected.
+    const dom3 = new JSDOM(`
+      <html><body class="logged-in admin-bar">
+        <div id="wpadminbar">
+          <li id="wp-admin-bar-user-info">
+            <img alt="" src="javascript:alert(1)" class="avatar">
+          </li>
+        </div>
+      </body></html>
+    `);
+    const ctx3 = loadModules(dom3);
+    const det3 = ctx3.WPDetect.detectWordPress(ctx3.document, { origin: 'https://example.com' });
+    assert(det3.context.userAvatarUrl === null, 'javascript: avatar URL rejected');
+
+    // Super admin signal — multisite renders #wp-admin-bar-network-admin
+    // only when the current user is a super admin. Single-site installs
+    // (or non-super-admins on multisite) never get the wrapper node.
+    const domSuper = new JSDOM(`
+      <html><body class="logged-in admin-bar">
+        <div id="wpadminbar">
+          <li id="wp-admin-bar-my-sites">
+            <li id="wp-admin-bar-network-admin">
+              <li id="wp-admin-bar-network-admin-d"><a href="/wp-admin/network/">Network Dashboard</a></li>
+            </li>
+          </li>
+        </div>
+      </body></html>
+    `);
+    const ctxSuper = loadModules(domSuper);
+    const detSuper = ctxSuper.WPDetect.detectWordPress(ctxSuper.document, { origin: 'https://example.com' });
+    assert(detSuper.context.isSuperAdmin === true,
+      'super admin detected from #wp-admin-bar-network-admin');
+
+    const domPlain = new JSDOM(`
+      <html><body class="logged-in admin-bar">
+        <div id="wpadminbar">
+          <li id="wp-admin-bar-my-account"><a href="/wp-admin/profile.php">Hi</a></li>
+        </div>
+      </body></html>
+    `);
+    const ctxPlain = loadModules(domPlain);
+    const detPlain = ctxPlain.WPDetect.detectWordPress(ctxPlain.document, { origin: 'https://example.com' });
+    assert(detPlain.context.isSuperAdmin === false,
+      'plain logged-in user (no network admin menu) is not flagged as super admin');
+  }
+
   // --- 12. Not a WordPress site -----------------------------------------
   {
     console.log('\n[12] Non-WordPress page');


### PR DESCRIPTION
## Summary

Adds a circular, bordered avatar button in the popup header (upper right) that opens a Popover-driven account menu. Replaces the standalone Log Out row, the "Logged in" badge, and the in-section login buttons with a single, focused affordance.

- **Logged in dropdown:** Profile · Account Settings · Log Out (two-click confirm).
- **Logged out dropdown:** Log In · Log In, Return to Page (silhouette avatar).
- **Role line** under the display name: shows "Super Admin" when detected from the admin bar, otherwise the first REST role slug, title-cased.

## What's in here

**Detection (`lib/detect.js`)**
- Captures user avatar URL, display name, and edit-profile href from the admin bar's My Account / User Info menus, with a `http(s):`/`data:` scheme allowlist.
- Detects multisite **Super Admin** from `#wp-admin-bar-network-admin` — the synchronous source of truth, since on multisite a super admin's per-site `wp_capabilities` is often just `subscriber`, which would otherwise mislabel them.

**REST (`lib/rest.js`, `content.js`, `src/popup/lib/actions.js`)**
- New `fetchCurrentUser` → `/wp/v2/users/me?context=edit` (the `edit` context is what exposes the `roles` field).
- New `GET_CURRENT_USER` content-script message.
- Factored the MAIN-world nonce extraction (plus the `wp-admin/profile.php` fallback) out of `requestSiteInfo` into a shared `resolveRestNonce` helper so the new action reuses it.

**UI (`src/popup/components/UserMenu.js`, `Header.js`, `DetectedView.js`)**
- Built on `@wordpress/ui` `Popover.Root` / `Trigger` / `Popup` / `Close` (the library's only menu primitive in this version) plus `VisuallyHidden` + `Popover.Title` to satisfy the a11y contract without a visible heading.
- Non-destructive items use `Popover.Close` so they auto-dismiss; the destructive logout stays a plain button to keep its two-click confirm intact.
- Role is pre-fetched on mount (not on first dropdown open) so the label is already there when the user clicks.

**Tests (`test/smoke.js`)**
- `[20]` user-info extraction (64×64 preferred over 26×26, top-level fallback, `javascript:` rejected), plus super-admin detection positive + negative.
- `[21]` `fetchCurrentUser` URL/headers/null-on-401 contract.

## Out of scope

- `dist/` was **not** rebuilt for this PR (the convention in this repo seems to be: refresh build output at release time, keeps PR diffs reviewable). Run `npm run build` locally to preview.

## Test plan

- [ ] Open the popup on a logged-in WP site → avatar appears in top-right with a thin circular border.
- [ ] Click the avatar → dropdown opens, shows display name + role.
- [ ] Profile / Account Settings open `/wp-admin/profile.php` in the current tab.
- [ ] Log Out → first click reveals "Click again to confirm"; second click signs out via the admin-bar `_wpnonce` (skipping WP's "Are you sure?" page).
- [ ] Open on a multisite super-admin account → role line reads **"Super Admin"** (not "Subscriber").
- [ ] Open on a logged-out WP site → silhouette avatar, dropdown shows Log In / Log In, Return to Page.
- [ ] `cd test && npm test` → all green (including the two new scenarios).
- [ ] Escape and outside-click both dismiss the dropdown.