### PR TITLE
Default to showing the admin bar on new origins

### DIFF
--- a/content.js
+++ b/content.js
@@ -48,10 +48,11 @@
     try {
       const data = await chrome.storage.local.get('wp_preferences_v1');
       const prefs = (data.wp_preferences_v1 || {})[location.origin];
-      // Default: hidden.
-      return !prefs || prefs.adminBarHidden !== false;
+      // Default: shown. Hide only when the user has explicitly toggled
+      // it off for this origin.
+      return !!prefs && prefs.adminBarHidden === true;
     } catch (_) {
-      return true;
+      return false;
     }
   }
 

--- a/lib/early.js
+++ b/lib/early.js
@@ -29,7 +29,7 @@
     const prefs = (prefsData.wp_preferences_v1 || {})[origin];
 
     const isKnownWP = entry && entry.isWordPress;
-    const shouldHide = !prefs || prefs.adminBarHidden !== false;
+    const shouldHide = prefs && prefs.adminBarHidden === true;
 
     if (!isKnownWP || !shouldHide) return;
 

--- a/src/popup/hooks/usePrefs.js
+++ b/src/popup/hooks/usePrefs.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 const PREFS_KEY = 'wp_preferences_v1';
-const DEFAULT_PREFS = { adminBarHidden: true, blockInspectorEnabled: false };
+const DEFAULT_PREFS = { adminBarHidden: false, blockInspectorEnabled: false };
 
 export function usePrefs(origin) {
 	const [prefs, setPrefs] = useState(DEFAULT_PREFS);


### PR DESCRIPTION
## Summary

Closes #6 by flipping the per-origin default for \`adminBarHidden\` from \`true\` to \`false\`. New WordPress origins now show the admin bar by default; the existing per-site Hide toggle in the popup still works as before, and previously-saved per-origin values are preserved.

## Why this instead of a global preference

#6 offered two paths: "make it opt-in" or "make the setting global." This PR takes the first. PR #8 attempted the second but collapsed the per-site choice into a single browser-wide setting, which is a regression for users who manage multiple WordPress sites with different preferences (e.g., hide on client sites, show on personal). Per-origin storage stays.

A future extension options page can add a global "Hide admin bar by default" toggle that flips the per-origin default for origins the user has not explicitly set — global *override*, not global *replacement*. That captures the global-preference intent from the second half of #6 without removing per-site control.

## What changed

| File | Change |
|---|---|
| \`lib/early.js\` | The early-load hide check now requires an explicit per-origin \`adminBarHidden === true\` instead of treating "no saved value" as hidden. |
| \`content.js\` | Same flip in \`loadAdminBarPref\`. Storage errors now resolve to "shown" instead of "hidden" (safer default for the broken-storage case). |
| \`src/popup/hooks/usePrefs.js\` | \`DEFAULT_PREFS.adminBarHidden\` is now \`false\`. The popup's toggle reflects the new default. |

Three small surgical changes; no UI restructuring, no new dependencies.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`node test/smoke.js\` — all assertions pass
- [x] \`npm run build:safari\` — Safari Resources synced
- [ ] Verify in Chrome on a fresh WP site (no saved prefs): admin bar visible, "Show Admin Bar" toggle is on
- [ ] Toggle off on that site → admin bar hides → reload → still hidden (per-origin save works)
- [ ] Toggle back on → admin bar visible → reload → still visible
- [ ] Open another WP site (different origin) → admin bar visible by default (no cross-site bleed)
- [ ] Verify existing installs with a saved \`adminBarHidden: true\` value still hide as before

Closes #6.