### PR TITLE
Add extension options page with admin bar default and data reset

### DIFF
--- a/content.js
+++ b/content.js
@@ -47,10 +47,15 @@
   async function loadAdminBarPref() {
     try {
       const data = await chrome.storage.local.get('wp_preferences_v1');
-      const prefs = (data.wp_preferences_v1 || {})[location.origin];
-      // Default: shown. Hide only when the user has explicitly toggled
-      // it off for this origin.
-      return !!prefs && prefs.adminBarHidden === true;
+      const prefsRoot = data.wp_preferences_v1 || {};
+      const prefs = prefsRoot[location.origin];
+      const globalPrefs = prefsRoot._global || {};
+      // Per-origin choice wins; otherwise consult the global "hide by
+      // default" option set on the options page; otherwise default to shown.
+      if (prefs && typeof prefs.adminBarHidden === 'boolean') {
+        return prefs.adminBarHidden === true;
+      }
+      return globalPrefs.adminBarHidden === true;
     } catch (_) {
       return false;
     }

--- a/lib/early.js
+++ b/lib/early.js
@@ -26,10 +26,17 @@
     ]);
 
     const entry = (cacheData.wp_detection_cache_v1 || {})[origin];
-    const prefs = (prefsData.wp_preferences_v1 || {})[origin];
+    const prefsRoot = prefsData.wp_preferences_v1 || {};
+    const prefs = prefsRoot[origin];
+    const globalPrefs = prefsRoot._global || {};
 
     const isKnownWP = entry && entry.isWordPress;
-    const shouldHide = prefs && prefs.adminBarHidden === true;
+    // Per-origin choice wins. The global "hide by default" option from the
+    // options page only fires for sites the user has not explicitly set.
+    const hasOriginPref = prefs && typeof prefs.adminBarHidden === 'boolean';
+    const shouldHide = hasOriginPref
+      ? prefs.adminBarHidden === true
+      : globalPrefs.adminBarHidden === true;
 
     if (!isKnownWP || !shouldHide) return;
 

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,11 @@
     "default_popup": "popup/popup.html"
   },
 
+  "options_ui": {
+    "page": "options/options.html",
+    "open_in_tab": true
+  },
+
   "background": {
     "service_worker": "background.js"
   },

--- a/options/options.css
+++ b/options/options.css
@@ -1,0 +1,131 @@
+:root {
+	color-scheme: light dark;
+	--wpd-text: #1e1e1e;
+	--wpd-text-muted: #5a5a5a;
+	--wpd-bg: #ffffff;
+	--wpd-surface: #f6f7f7;
+	--wpd-border: #dcdcde;
+	--wpd-accent: #2271b1;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--wpd-text: #e4e4e7;
+		--wpd-text-muted: #a1a1aa;
+		--wpd-bg: #1e1e1e;
+		--wpd-surface: #2a2a2a;
+		--wpd-border: #3f3f46;
+	}
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+	margin: 0;
+	padding: 0;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+	background: var(--wpd-bg);
+	color: var(--wpd-text);
+	line-height: 1.5;
+}
+
+.wpd-options {
+	max-width: 640px;
+	margin: 0 auto;
+	padding: 32px 24px 48px;
+}
+
+.wpd-options__header {
+	margin-bottom: 24px;
+	padding-bottom: 16px;
+	border-bottom: 1px solid var(--wpd-border);
+}
+
+.wpd-options__header h1 {
+	margin: 0 0 4px;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.wpd-options__subtitle {
+	margin: 0;
+	color: var(--wpd-text-muted);
+	font-size: 14px;
+}
+
+.wpd-options__section {
+	margin-top: 24px;
+}
+
+.wpd-options__section h2 {
+	margin: 0 0 12px;
+	font-size: 14px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--wpd-text-muted);
+}
+
+.wpd-option {
+	display: flex;
+	gap: 12px;
+	padding: 16px;
+	background: var(--wpd-surface);
+	border: 1px solid var(--wpd-border);
+	border-radius: 8px;
+	cursor: pointer;
+}
+
+.wpd-option input[type="checkbox"] {
+	margin: 3px 0 0;
+	accent-color: var(--wpd-accent);
+	width: 16px;
+	height: 16px;
+}
+
+.wpd-option__label {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.wpd-option__title {
+	font-size: 14px;
+	font-weight: 500;
+}
+
+.wpd-option__hint {
+	font-size: 13px;
+	color: var(--wpd-text-muted);
+}
+
+.wpd-option--action {
+	align-items: center;
+	justify-content: space-between;
+}
+
+.wpd-button {
+	flex: 0 0 auto;
+	padding: 6px 12px;
+	font-size: 13px;
+	font-family: inherit;
+	color: var(--wpd-text);
+	background: var(--wpd-bg);
+	border: 1px solid var(--wpd-border);
+	border-radius: 6px;
+	cursor: pointer;
+}
+
+.wpd-button:hover {
+	border-color: var(--wpd-text-muted);
+}
+
+.wpd-options__status {
+	margin: 8px 4px 0;
+	min-height: 1em;
+	font-size: 13px;
+	color: var(--wpd-text-muted);
+}
+
+.wpd-options__status[data-tone="ok"] { color: #1a7f37; }
+.wpd-options__status[data-tone="error"] { color: #c4314b; }

--- a/options/options.html
+++ b/options/options.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>WordPress Browser Extension — Options</title>
+	<link rel="stylesheet" href="options.css">
+</head>
+<body>
+	<main class="wpd-options">
+		<header class="wpd-options__header">
+			<h1>WordPress Browser Extension</h1>
+			<p class="wpd-options__subtitle">Browser-wide defaults. Per-site choices still live in the toolbar popup.</p>
+		</header>
+
+		<section class="wpd-options__section">
+			<h2>Admin bar</h2>
+			<label class="wpd-option">
+				<input type="checkbox" id="adminBarHiddenDefault">
+				<span class="wpd-option__label">
+					<span class="wpd-option__title">Hide admin bar by default</span>
+					<span class="wpd-option__hint">When enabled, the admin bar starts hidden on new WordPress sites. Per-site preferences in the popup still take precedence.</span>
+				</span>
+			</label>
+		</section>
+
+		<section class="wpd-options__section">
+			<h2>Data</h2>
+			<div class="wpd-option wpd-option--action">
+				<div class="wpd-option__label">
+					<span class="wpd-option__title">Reset extension data</span>
+					<span class="wpd-option__hint">Clears every saved per-site preference, the global defaults set on this page, and the cached "is this a WordPress site" results. Useful for testing or starting fresh.</span>
+				</div>
+				<button type="button" id="resetData" class="wpd-button">Clear all data</button>
+			</div>
+			<p id="resetStatus" class="wpd-options__status" role="status" aria-live="polite"></p>
+		</section>
+	</main>
+	<script src="options.js"></script>
+</body>
+</html>

--- a/options/options.js
+++ b/options/options.js
@@ -1,0 +1,67 @@
+/**
+ * Reads and writes the browser-wide defaults that live alongside the
+ * per-origin preferences in `wp_preferences_v1._global`. Per-origin
+ * values always win over these defaults; this page only affects sites
+ * the user has not explicitly toggled.
+ */
+const PREFS_KEY = 'wp_preferences_v1';
+const CACHE_KEY = 'wp_detection_cache_v1';
+const GLOBAL_NS = '_global';
+
+const adminBarToggle = document.getElementById('adminBarHiddenDefault');
+const resetButton = document.getElementById('resetData');
+const resetStatus = document.getElementById('resetStatus');
+
+async function loadGlobalPrefs() {
+	try {
+		const data = await chrome.storage.local.get(PREFS_KEY);
+		return (data[PREFS_KEY] || {})[GLOBAL_NS] || {};
+	} catch (_) {
+		return {};
+	}
+}
+
+async function saveGlobalPref(key, value) {
+	try {
+		const data = await chrome.storage.local.get(PREFS_KEY);
+		const root = data[PREFS_KEY] || {};
+		const next = { ...(root[GLOBAL_NS] || {}), [key]: value };
+		await chrome.storage.local.set({ [PREFS_KEY]: { ...root, [GLOBAL_NS]: next } });
+	} catch (_) { /* storage write failed; UI stays unsynced until next reload */ }
+}
+
+(async () => {
+	const globalPrefs = await loadGlobalPrefs();
+	adminBarToggle.checked = globalPrefs.adminBarHidden === true;
+
+	adminBarToggle.addEventListener('change', () => {
+		saveGlobalPref('adminBarHidden', adminBarToggle.checked);
+	});
+
+	// Reflect changes that arrive from another tab or context.
+	chrome.storage.onChanged.addListener((changes, area) => {
+		if (area !== 'local' || !changes[PREFS_KEY]) return;
+		const incoming = (changes[PREFS_KEY].newValue || {})[GLOBAL_NS] || {};
+		adminBarToggle.checked = incoming.adminBarHidden === true;
+	});
+
+	resetButton.addEventListener('click', async () => {
+		const ok = window.confirm(
+			'Clear all extension data?\n\nThis removes every saved per-site preference, the global defaults on this page, and the cached WordPress detection results. Cannot be undone.',
+		);
+		if (!ok) return;
+		try {
+			await chrome.storage.local.remove([PREFS_KEY, CACHE_KEY]);
+			adminBarToggle.checked = false;
+			resetStatus.textContent = 'Cleared.';
+			resetStatus.dataset.tone = 'ok';
+		} catch (_) {
+			resetStatus.textContent = 'Could not clear data. Try again.';
+			resetStatus.dataset.tone = 'error';
+		}
+		setTimeout(() => {
+			resetStatus.textContent = '';
+			delete resetStatus.dataset.tone;
+		}, 4000);
+	});
+})();

--- a/safari/WordPress Browser Extension/WordPress Browser Extension.xcodeproj/project.pbxproj
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		23E1696C2FB90D4D00B58EF4 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 23E169652FB90D4D00B58EF4 /* manifest.json */; };
 		23E1696D2FB90D4D00B58EF4 /* lib in Resources */ = {isa = PBXBuildFile; fileRef = 23E169662FB90D4D00B58EF4 /* lib */; };
 		23E1696E2FB90D4D00B58EF4 /* content.js in Resources */ = {isa = PBXBuildFile; fileRef = 23E169672FB90D4D00B58EF4 /* content.js */; };
+		23E16A022FB90D4D00B58EF4 /* options in Resources */ = {isa = PBXBuildFile; fileRef = 23E16A012FB90D4D00B58EF4 /* options */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,6 +72,7 @@
 		23E169652FB90D4D00B58EF4 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = manifest.json; path = Resources/manifest.json; sourceTree = "<group>"; };
 		23E169662FB90D4D00B58EF4 /* lib */ = {isa = PBXFileReference; lastKnownFileType = folder; name = lib; path = Resources/lib; sourceTree = "<group>"; };
 		23E169672FB90D4D00B58EF4 /* content.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; name = content.js; path = Resources/content.js; sourceTree = "<group>"; };
+		23E16A012FB90D4D00B58EF4 /* options */ = {isa = PBXFileReference; lastKnownFileType = folder; name = options; path = Resources/options; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -153,6 +155,7 @@
 				23E169652FB90D4D00B58EF4 /* manifest.json */,
 				23E169662FB90D4D00B58EF4 /* lib */,
 				23E169672FB90D4D00B58EF4 /* content.js */,
+				23E16A012FB90D4D00B58EF4 /* options */,
 			);
 			name = Resources;
 			path = "WordPress Browser Extension Extension";
@@ -264,6 +267,7 @@
 				23E169692FB90D4D00B58EF4 /* background.js in Resources */,
 				23E1696E2FB90D4D00B58EF4 /* content.js in Resources */,
 				23E169682FB90D4D00B58EF4 /* popup in Resources */,
+				23E16A022FB90D4D00B58EF4 /* options in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/scripts/package-chrome.sh
+++ b/scripts/package-chrome.sh
@@ -25,7 +25,7 @@ echo "Building popup bundle..."
 npm run build > /dev/null
 
 rm -rf "$STAGE"
-mkdir -p "$STAGE/lib" "$STAGE/popup" "$STAGE/dist" "$STAGE/icons"
+mkdir -p "$STAGE/lib" "$STAGE/popup" "$STAGE/options" "$STAGE/dist" "$STAGE/icons"
 
 cp manifest.json    "$STAGE/"
 cp background.js    "$STAGE/"
@@ -38,6 +38,10 @@ cp lib/host.js             "$STAGE/lib/"
 cp lib/block-inspector.js  "$STAGE/lib/"
 
 cp popup/popup.html "$STAGE/popup/"
+
+cp options/options.html "$STAGE/options/"
+cp options/options.css  "$STAGE/options/"
+cp options/options.js   "$STAGE/options/"
 
 cp dist/popup.css "$STAGE/dist/"
 cp dist/popup.js  "$STAGE/dist/"

--- a/scripts/sync-safari.sh
+++ b/scripts/sync-safari.sh
@@ -20,8 +20,8 @@ fi
 
 # Wipe sub-folders so deletes in source propagate; top-level files are
 # overwritten below so the DEST listing matches source exactly.
-rm -rf "$DEST/lib" "$DEST/popup" "$DEST/dist" "$DEST/icons"
-mkdir -p "$DEST/lib" "$DEST/popup" "$DEST/dist" "$DEST/icons"
+rm -rf "$DEST/lib" "$DEST/popup" "$DEST/options" "$DEST/dist" "$DEST/icons"
+mkdir -p "$DEST/lib" "$DEST/popup" "$DEST/options" "$DEST/dist" "$DEST/icons"
 
 cp "$ROOT/manifest.json" "$DEST/"
 cp "$ROOT/background.js" "$DEST/"
@@ -34,6 +34,10 @@ cp "$ROOT/lib/host.js"             "$DEST/lib/"
 cp "$ROOT/lib/block-inspector.js"  "$DEST/lib/"
 
 cp "$ROOT/popup/popup.html" "$DEST/popup/"
+
+cp "$ROOT/options/options.html" "$DEST/options/"
+cp "$ROOT/options/options.css"  "$DEST/options/"
+cp "$ROOT/options/options.js"   "$DEST/options/"
 
 cp "$ROOT/dist/popup.css" "$DEST/dist/"
 cp "$ROOT/dist/popup.js"  "$DEST/dist/"

--- a/src/popup/hooks/usePrefs.js
+++ b/src/popup/hooks/usePrefs.js
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useState } from 'react';
 
 const PREFS_KEY = 'wp_preferences_v1';
+const GLOBAL_NS = '_global';
 const DEFAULT_PREFS = { adminBarHidden: false, blockInspectorEnabled: false };
+
+// Per-origin pref wins. Falls back to whatever the global namespace sets on
+// the options page; falls back to the hard-coded defaults if neither exists.
+function mergePrefs(globalPrefs, originPrefs) {
+	return { ...DEFAULT_PREFS, ...globalPrefs, ...originPrefs };
+}
 
 export function usePrefs(origin) {
 	const [prefs, setPrefs] = useState(DEFAULT_PREFS);
@@ -11,7 +18,7 @@ export function usePrefs(origin) {
 		(async () => {
 			const data = await chrome.storage.local.get(PREFS_KEY);
 			const all = data[PREFS_KEY] || {};
-			setPrefs({ ...DEFAULT_PREFS, ...(all[origin] || {}) });
+			setPrefs(mergePrefs(all[GLOBAL_NS] || {}, all[origin] || {}));
 		})();
 	}, [origin]);
 
@@ -20,7 +27,7 @@ export function usePrefs(origin) {
 			setPrefs((prev) => ({ ...prev, [key]: value }));
 			const data = await chrome.storage.local.get(PREFS_KEY);
 			const all = data[PREFS_KEY] || {};
-			all[origin] = { ...DEFAULT_PREFS, ...(all[origin] || {}), [key]: value };
+			all[origin] = { ...(all[origin] || {}), [key]: value };
 			await chrome.storage.local.set({ [PREFS_KEY]: all });
 		},
 		[origin],


### PR DESCRIPTION
## Summary

Introduces an extension options page surfaced through \`chrome://extensions\` (or Safari → Settings → Extensions). No entry point from the popup — the page is intentionally out of the way, for browser-wide defaults users specifically go looking for.

Two controls to start:

### 1. Hide admin bar by default
Closes the global-preference half of #6 (the per-origin default flip in #17 closed the muscle-memory half). Stored in \`wp_preferences_v1._global\` as a global namespace inside the existing prefs key. **Per-origin choices always win**; this default fires only on sites the user has not explicitly toggled.

\`lib/early.js\`, \`content.js\`, and the popup's \`usePrefs\` hook all consult the global namespace as a fallback after the per-origin check.

### 2. Clear all data
Removes both \`wp_preferences_v1\` (per-site toggles and the global namespace) and \`wp_detection_cache_v1\` (the WP-detection cache). Neither Chrome nor Safari expose a built-in way to wipe an extension's storage, and this gap matters for testing, support flows ("clear your settings and try again"), and starting fresh.

## Implementation notes

- Plain HTML + JS + CSS for the options page (no webpack entry point) — keeps the bundle simple and the page lightweight.
- Light/dark mode adapt via \`prefers-color-scheme\`.
- \`scripts/package-chrome.sh\` and \`scripts/sync-safari.sh\` now copy \`options/\` into the shipping bundle.
- The Safari Xcode project picks up the new folder via a \`lastKnownFileType = folder\` reference in \`project.pbxproj\`, matching how \`popup/\`, \`lib/\`, \`dist/\`, and \`icons/\` are declared. Validated via \`plutil -lint\`.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`node test/smoke.js\` — passes
- [x] \`npm run build:safari\` and \`npm run package:chrome\` — both produce bundles with \`options/\` included
- [x] Chrome: chrome://extensions → Details → Extension options → page renders, toggle persists, clear button works
- [x] Safari: container rebuilt → preferences pane in Safari → Settings → Extensions opens the options page
- [x] Toggle "Hide admin bar by default" on → admin bar hides on a site with no per-origin pref
- [x] Toggle "Show admin bar" in the popup on that same site → per-origin choice wins → admin bar shows even with global "hide" set
- [x] Clear data → toggle resets to off, detection cache emptied