### PR TITLE
Attribute the admin bar hide to the extension

### DIFF
--- a/content.js
+++ b/content.js
@@ -66,11 +66,17 @@
       hideStyle = document.createElement('style');
       hideStyle.id = 'wp-detective-adminbar-hide';
       hideStyle.textContent = `
+        /*
+         * Admin bar hidden by the WordPress Browser Extension.
+         * Toggle "Show Admin Bar" in the extension popup to restore it on
+         * this site, or change the default in the extension options page.
+         */
         #wpadminbar { display: none !important; }
         html { margin-top: 0 !important; --wp-admin--admin-bar--height: 0px !important; }
         html.admin-bar, html.wp-toolbar { margin-top: 0 !important; --wp-admin--admin-bar--height: 0px !important; }
       `;
       document.documentElement.appendChild(hideStyle);
+      console.info('[WordPress Browser Extension] Admin bar hidden on this site. Toggle "Show Admin Bar" in the extension popup or the options page.');
     }
     // Remove `body.admin-bar` so themes that key layout off it (e.g.
     // `body.admin-bar .header { padding-top: 32px }`) collapse cleanly

--- a/lib/early.js
+++ b/lib/early.js
@@ -43,12 +43,18 @@
     const style = document.createElement('style');
     style.id = 'wp-detective-adminbar-hide';
     style.textContent = `
+      /*
+       * Admin bar hidden by the WordPress Browser Extension.
+       * Toggle "Show Admin Bar" in the extension popup to restore it on
+       * this site, or change the default in the extension options page.
+       */
       #wpadminbar { display: none !important; }
       html { margin-top: 0 !important; --wp-admin--admin-bar--height: 0px !important; }
       html.admin-bar, html.wp-toolbar { margin-top: 0 !important; --wp-admin--admin-bar--height: 0px !important; }
     `;
     // documentElement exists even before <head>, so this is always safe.
     document.documentElement.appendChild(style);
+    console.info('[WordPress Browser Extension] Admin bar hidden on this site. Toggle "Show Admin Bar" in the extension popup or the options page.');
   } catch (_) {
     // Storage unavailable or extension context invalidated — ignore.
   }


### PR DESCRIPTION
## Summary

Closes #12. When the popup or options-page preference asks the extension to hide the admin bar, the only previous signal was a \`<style>\` element with an opaque id. That doesn't surface in the inspector's Styles panel, so a developer trying to figure out where their admin bar went had no good signal to follow.

Two small additions:

1. **CSS comment** at the top of the injected style block, naming the extension and pointing at both controls that turn it back on (popup toggle + options page). The comment renders in the inspector's Styles panel right next to the rule.
2. **\`console.info\`** on injection, for the "open devtools and look for a clue" instinct. One line, no noise.

Both injection paths are covered:
- \`lib/early.js\` at document_start, for cached known-WP sites where we hide the bar before it can paint.
- \`content.js\` at document_idle, for the cold-load case (no cache yet) and the popup-triggered case (user toggles "Show Admin Bar" off).

## Test plan

- [x] \`npm run build\` — clean
- [x] \`node test/smoke.js\` — passes (no test changes; injection mechanics aren't covered by smoke today)
- [ ] Visit a WP site with the per-origin "hide" preference set: open inspector → \`#wpadminbar\` rule shows the attribution comment above it
- [ ] Same site: console shows the one-line \`[WordPress Browser Extension] Admin bar hidden on this site...\` message
- [ ] Toggle "Show Admin Bar" in the popup → style block removed → reload → no attribution comment (admin bar visible, as expected)
- [ ] Visit a WP site with no per-origin preference and "Hide admin bar by default" enabled in options → same attribution shows