### PR TITLE
Make the Site Information panel an experimental opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,17 @@ See [`SAFARI.md`](SAFARI.md) — requires Xcode and a one-time Xcode Run (⌘R).
 - **Identify the host** — Detects WP Engine, WordPress VIP, Pantheon, Kinsta, Flywheel, Cloudways, WordPress.com, Pressable, and local dev environments. Cached per origin for 90 days.
 - **Toggle the admin bar** — Hide or show the front-end admin bar per site, without flash. Honors your profile setting and surfaces a clear hint when WP itself has the bar disabled.
 - **One-click sign out** — Inline confirm, then logs out via the admin bar's nonce so WordPress's "are you sure?" page is skipped.
-- **Site Information panel** — Active theme (name, version, author) and a wrap of plugin pills with version-on-hover. Pills link to each plugin's homepage. Powered by the WP REST API for admins, with DOM-scanned slugs as a graceful fallback.
 - **Developer tools** — Mobile preview window (iPhone-sized), bypass page cache, clear cookies + site data (preserving your WP login), Highlight Blocks (outline `wp-block-*` elements with a breadcrumb tooltip), and a Query Monitor toggle when QM is installed.
+
+## Options page
+
+Browser-wide defaults live on a separate options page, surfaced through the browser's extension management UI (Chrome: `chrome://extensions` → Details → Extension options. Safari: Settings → Extensions → preferences pane). No entry point from the popup — these settings are intentionally out of the way.
+
+Current options:
+
+- **Hide admin bar by default** — Flips the per-site default for the admin bar toggle. Per-site choices in the popup always win over this default.
+- **Show site information panel (experimental)** — Adds a panel to the popup that surfaces the active theme, installed plugins, site name, and REST namespaces. Detection is heuristic and asset-path inference can produce duplicates or false positives, so it is off by default. Powered by the WP REST API for admins, with DOM-scanned slugs as a graceful fallback.
+- **Clear all data** — Wipes per-site preferences, the global defaults above, and the cached WordPress detection results. Useful for testing or starting fresh.
 
 ## Development
 

--- a/options/options.html
+++ b/options/options.html
@@ -24,6 +24,17 @@
 		</section>
 
 		<section class="wpd-options__section">
+			<h2>Experimental</h2>
+			<label class="wpd-option">
+				<input type="checkbox" id="siteInfoEnabled">
+				<span class="wpd-option__label">
+					<span class="wpd-option__title">Show site information panel</span>
+					<span class="wpd-option__hint">Adds a panel to the popup that surfaces the active theme, installed plugins, site name, and REST namespaces. Detection is heuristic — asset-path inference can produce duplicates and false positives (for example mu-plugins and drop-ins). Off by default.</span>
+				</span>
+			</label>
+		</section>
+
+		<section class="wpd-options__section">
 			<h2>Data</h2>
 			<div class="wpd-option wpd-option--action">
 				<div class="wpd-option__label">

--- a/options/options.js
+++ b/options/options.js
@@ -9,6 +9,7 @@ const CACHE_KEY = 'wp_detection_cache_v1';
 const GLOBAL_NS = '_global';
 
 const adminBarToggle = document.getElementById('adminBarHiddenDefault');
+const siteInfoToggle = document.getElementById('siteInfoEnabled');
 const resetButton = document.getElementById('resetData');
 const resetStatus = document.getElementById('resetStatus');
 
@@ -33,9 +34,14 @@ async function saveGlobalPref(key, value) {
 (async () => {
 	const globalPrefs = await loadGlobalPrefs();
 	adminBarToggle.checked = globalPrefs.adminBarHidden === true;
+	siteInfoToggle.checked = globalPrefs.siteInfoEnabled === true;
 
 	adminBarToggle.addEventListener('change', () => {
 		saveGlobalPref('adminBarHidden', adminBarToggle.checked);
+	});
+
+	siteInfoToggle.addEventListener('change', () => {
+		saveGlobalPref('siteInfoEnabled', siteInfoToggle.checked);
 	});
 
 	// Reflect changes that arrive from another tab or context.
@@ -43,6 +49,7 @@ async function saveGlobalPref(key, value) {
 		if (area !== 'local' || !changes[PREFS_KEY]) return;
 		const incoming = (changes[PREFS_KEY].newValue || {})[GLOBAL_NS] || {};
 		adminBarToggle.checked = incoming.adminBarHidden === true;
+		siteInfoToggle.checked = incoming.siteInfoEnabled === true;
 	});
 
 	resetButton.addEventListener('click', async () => {
@@ -53,6 +60,7 @@ async function saveGlobalPref(key, value) {
 		try {
 			await chrome.storage.local.remove([PREFS_KEY, CACHE_KEY]);
 			adminBarToggle.checked = false;
+			siteInfoToggle.checked = false;
 			resetStatus.textContent = 'Cleared.';
 			resetStatus.dataset.tone = 'ok';
 		} catch (_) {

--- a/src/popup/components/DetectedView.js
+++ b/src/popup/components/DetectedView.js
@@ -23,6 +23,7 @@ export function DetectedView({ result, host }) {
 	const isLoggedIn = !!ctx.isLoggedIn;
 	const hostname = useMemo(() => new URL(origin).hostname, [origin]);
 	const isWpAdmin = useMemo(() => /\/wp-admin(\/|$)/.test(new URL(url).pathname), [url]);
+	const [prefs] = usePrefs(origin);
 
 	const openInNewTab = (url) => {
 		chrome.tabs.create({ url });
@@ -68,7 +69,9 @@ export function DetectedView({ result, host }) {
 			{isLoggedIn && ctx.newContentItems?.length > 0 && (
 				<NewContent items={ctx.newContentItems} onOpen={openUrl} />
 			)}
-			<SiteInfoPanel ctx={ctx} origin={origin} onOpen={openUrl} />
+			{prefs.siteInfoEnabled && (
+				<SiteInfoPanel ctx={ctx} origin={origin} onOpen={openUrl} />
+			)}
 			{!isWpAdmin && (
 				<DevTools origin={origin} url={url} hasQueryMonitor={!!ctx.hasQueryMonitor} qmOpen={!!ctx.qmOpen} />
 			)}

--- a/src/popup/hooks/usePrefs.js
+++ b/src/popup/hooks/usePrefs.js
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 
 const PREFS_KEY = 'wp_preferences_v1';
 const GLOBAL_NS = '_global';
-const DEFAULT_PREFS = { adminBarHidden: false, blockInspectorEnabled: false };
+const DEFAULT_PREFS = { adminBarHidden: false, blockInspectorEnabled: false, siteInfoEnabled: false };
 
 // Per-origin pref wins. Falls back to whatever the global namespace sets on
 // the options page; falls back to the hard-coded defaults if neither exists.


### PR DESCRIPTION
## Summary

The Site Information panel's plugin/theme detection relies on asset-path inference, which is inherently lossy. The same issue (#4) covers the symptom — duplicates from plugins that enqueue multiple asset paths, false positives from mu-plugins and drop-ins, slugs that don't match actual plugin folder names. None of those are bugs to fix; they're the nature of frontend-only inference.

For a 1.0 release, "show confidently-wrong data by default" is the wrong trade. Gate the panel behind an explicit opt-in on the options page, framed as experimental.

## Changes

- \`src/popup/hooks/usePrefs.js\` — adds \`siteInfoEnabled: false\` to \`DEFAULT_PREFS\`. Read through the existing global-namespace fallback.
- \`src/popup/components/DetectedView.js\` — pulls \`prefs\` via \`usePrefs\` and gates the \`<SiteInfoPanel>\` render on \`prefs.siteInfoEnabled\`.
- \`options/options.html\`, \`options/options.js\` — new "Experimental" section with the toggle, wired to the same storage layer as the other global preferences.
- \`README.md\` — describes the options page surface and notes the experimental section.

The panel's existing source code is untouched. Users who turn it on get exactly what shipped before.

## Test plan

- [x] \`npm run build\` — clean
- [x] \`node test/smoke.js\` — passes
- [ ] Reload Chrome → open the popup on a WP site → Site Information panel should be absent.
- [ ] Open options page → "Experimental" section visible → toggle "Show site information panel" on.
- [ ] Reopen the popup → Site Information panel renders as before, with all detection behavior identical to the pre-PR version.
- [ ] Toggle off → panel hidden again.
- [ ] Same flow in Safari after container rebuild.

Closes #4.