### PR TITLE
Sync docs with v0.9 changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,12 @@ For UX questions, "should we…?" discussions, demo recordings, or feature ideas
 git clone https://github.com/WordPress/browser-extension.git
 cd browser-extension
 npm install
-npm run build     # production bundle → dist/
+npm run build     # production bundle → dist/popup.{js,css}
 # OR
 npm start         # watch mode for development
 ```
 
-Load the repo into Chrome via `chrome://extensions` → Developer mode → **Load unpacked**, pointing at the repo root (the manifest sits at the top level; the popup bundle lives under `dist/popup/`).
+Load the repo into Chrome via `chrome://extensions` → Developer mode → **Load unpacked**, pointing at the repo root (the manifest sits at the top level; the popup bundle is at `dist/popup.{js,css}`).
 
 For Safari development, see [`SAFARI.md`](SAFARI.md).
 
@@ -47,8 +47,8 @@ Smoke tests cover the vanilla `lib/*.js` modules. Test before opening a PR.
 
 ### Architecture notes
 
-- The popup UI is React + [`@wordpress/ui`](https://www.npmjs.com/package/@wordpress/ui), bundled with [10up-toolkit](https://github.com/10up/10up-toolkit) → `dist/popup/`.
-- The background service worker (`background.js`), content scripts (`content.js`), and `lib/*.js` are plain JavaScript — no build step there. Don't introduce a bundler dependency for those without discussion.
+- The popup UI is React + [`@wordpress/ui`](https://www.npmjs.com/package/@wordpress/ui), bundled with [`@wordpress/scripts`](https://www.npmjs.com/package/@wordpress/scripts) → `dist/popup.{js,css}`.
+- The background service worker (`background.js`), content scripts (`content.js`), `lib/*.js`, and the extension options page (`options/*`) are plain JavaScript — no build step there. Don't introduce a bundler dependency for those without discussion.
 - The Safari build re-uses the Chrome runtime via `npm run build:safari`, which rsyncs all shipping files into the Xcode project resources.
 
 ### Conventions

--- a/README.md
+++ b/README.md
@@ -46,14 +46,15 @@ See [`SAFARI.md`](SAFARI.md) — requires Xcode and a one-time Xcode Run (⌘R).
 
 ## Features
 
-- **Detect WordPress** — Identifies WP sites automatically via REST API links, generator tags, asset paths, and body classes. The toolbar icon has three states: gray with a slash for non-WP, gray for WP, blue for WP and logged in.
+- **Detect WordPress** — Identifies WP sites automatically via REST API links, generator tags, asset paths, and body classes. The toolbar icon has three states: a WordPress-blue circle when logged in to a WP site, dark gray when logged out on a WP site, and dark gray with a diagonal slash for non-WP pages. The full-bleed background keeps the icon legible against any browser chrome.
 - **Site icon in the popup header** — When a site has a WordPress Site Icon configured (Customize → Site Identity), it appears next to the hostname in the popup header for fast visual identification.
 - **Edit this page** — Jump straight to the editor for posts, pages, categories, tags, authors, and custom post types — including hyphenated CPT slugs like `case-study`. Keyboard shortcut: `Alt+Shift+E` (`Option+Shift+E` on Mac), customizable at `chrome://extensions/shortcuts`.
 - **View / Preview from the editor** — On wp-admin edit screens, see the published page or preview a draft (with nonce) in one click. Works for all post types.
 - **+ New content menu** — Mirrors the admin bar's "+ New" dropdown with the post types your role can create.
 - **Identify the host** — Detects WP Engine, WordPress VIP, Pantheon, Kinsta, Flywheel, Cloudways, WordPress.com, Pressable, and local dev environments. Cached per origin for 90 days.
 - **Toggle the admin bar** — Hide or show the front-end admin bar per site, without flash. Honors your profile setting and surfaces a clear hint when WP itself has the bar disabled.
-- **One-click sign out** — Inline confirm, then logs out via the admin bar's nonce so WordPress's "are you sure?" page is skipped.
+- **Account menu** — A circular avatar button in the popup header opens an account dropdown with the logged-in user's display name, role (Super Admin / Administrator / Editor / etc.), and one-click links to the WordPress profile and Gravatar (when the avatar comes from gravatar.com). Sourced from the admin bar's My Account menu.
+- **One-click sign out** — Inline confirm in the account menu, then logs out via the admin bar's nonce so WordPress's "are you sure?" page is skipped.
 - **Developer tools** — Mobile preview window (iPhone-sized), bypass page cache, clear cookies + site data (preserving your WP login), Highlight Blocks (outline `wp-block-*` elements with a breadcrumb tooltip), and a Query Monitor toggle when QM is installed.
 
 ## Options page
@@ -68,7 +69,7 @@ Current options:
 
 ## Development
 
-The popup UI is React + [`@wordpress/ui`](https://www.npmjs.com/package/@wordpress/ui), bundled with [10up-toolkit](https://github.com/10up/10up-toolkit). The background service worker, content scripts, and `lib/*.js` are plain JavaScript — no build step there.
+The popup UI is React + [`@wordpress/ui`](https://www.npmjs.com/package/@wordpress/ui), bundled with [`@wordpress/scripts`](https://www.npmjs.com/package/@wordpress/scripts). The background service worker, content scripts, `lib/*.js`, and the options page (`options/*`) are plain JavaScript — no build step there.
 
 ```
 npm install

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@ A milestone-level view of where this project is heading. Day-to-day work is trac
 
 | Phase | What | Status |
 |---|---|---|
-| **v0.8.x** | Public scaffold under the WordPress org. Feature work and polish on the v0.8 surface; React popup architecture, Site Information panel, Block Inspector, host detection, developer tools. | active (now) |
-| **v0.9.x** | **Features:** surface the logged-in user (display name + Gravatar) in the popup header. (Site icon next to the hostname shipped in v0.8.2.) **Store-prep:** permissions and API-surface review (trim to least-privilege). Xcode bundle identifier change from `com.fabiankaegy.wp-detective` to a WordPress-namespaced ID — coordinated with the Apple Developer account holder. (The Xcode project / display-name rename to "WordPress Browser Extension" shipped in v0.8.3.) | next |
+| **v0.8.x** | Public scaffold under the WordPress org. React popup architecture, Site Information panel, Block Inspector, host detection, developer tools. | shipped |
+| **v0.9.x** | **Features:** account menu in the popup header (display name, role, profile / Gravatar); extension options page with browser-wide preferences (admin bar default, Site Information opt-in, clear-data); toolbar icon redesigned for contrast on any browser chrome; admin bar attribution comment when the extension is hiding it. **Build:** popup bundle migrated from `10up-toolkit` to `@wordpress/scripts`. **Security:** REST root and profile URL validated against same-origin so a hostile page can't redirect the extension's authenticated calls. **Store-prep pending:** Xcode bundle identifier change from `com.fabiankaegy.wp-detective` to a WordPress-namespaced ID — coordinated with the Apple Developer account holder. Final permissions and API-surface review. (The Xcode project / display-name rename to "WordPress Browser Extension" shipped in v0.8.3.) | active (now) |
 | **v1.0** | Initial official directory releases under the WordPress publisher account: **Chrome Web Store** and **Safari / Mac App Store** (the two surfaces this codebase already ships). API and permissions surface frozen; deprecation policy locked. | gated by store-listing prep + WordPress Foundation alignment on publisher account |
 | **post-1.0** | Expansion to additional browser directories — **Firefox Add-ons (AMO)** (requires a manifest v2/v3 compatibility audit; Firefox's WebExtension surface diverges from Chromium in a few places) and **Edge Add-ons** (typically rides the Chrome Web Store submission, but the WordPress publisher-account question may differ). Ongoing host-detection additions as managed-WordPress platforms ship new signatures. | gated by 1.0 launch signal |
 
@@ -23,7 +23,7 @@ A working list of items the maintainers think need to land before the v1.0 store
 
 ## Intentionally out of scope (for now)
 
-- **Per-site overrides via a settings UI.** Today's model is per-feature toggles plus a 90-day per-origin host detection cache. A dedicated settings page is a possible v2 feature gated by demonstrated demand.
+- **A per-site settings page.** Today's model is browser-wide defaults on the extension options page plus per-feature toggles in the popup. A dedicated per-site settings page is a possible v2 feature gated by demonstrated demand.
 - **Bundled analytics or telemetry.** The extension is a developer/maintainer tool, not a tracking surface. No remote analytics are shipped.
 - **Mobile browsers** (Chrome Android, Safari iOS). Mobile WebExtension support is patchy and the use cases are weaker. Possible post-1.0.
 - **Multi-account / profile switching.** Out of scope at v1.0; the extension uses whatever WordPress login the current browser session has.

--- a/SAFARI.md
+++ b/SAFARI.md
@@ -41,8 +41,15 @@ The Xcode project references files it has its own copies of under
 `safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/`.
 `npm run build:safari` rebuilds the popup bundle and rsyncs every shipping
 runtime file into that folder, so re-run it whenever `manifest.json`,
-`background.js`, `content.js`, `lib/*`, `popup/popup.html`, or any icon
-changes.
+`background.js`, `content.js`, `lib/*`, `popup/popup.html`, `options/*`,
+or any icon changes.
+
+If new top-level files or folders are added to the runtime (e.g. a new
+`options/` folder shipped in v0.9), they also have to be registered in
+the Xcode project file (`WordPress Browser Extension.xcodeproj/project.pbxproj`)
+as a folder reference. Open the project in Xcode, drag the folder into
+the Resources group, and choose "Create folder references" so future
+files inside it sync automatically.
 
 ## Known issues
 


### PR DESCRIPTION
## Summary

Documentation sweep before the v0.9 release tag. Walks each .md and updates anything stale relative to today's merges.

## Files updated

- **README.md** — toolbar icon description matches the redesigned full-bleed circle (was the old transparent-W silhouette); new "Account menu" bullet under Features; build tool renamed from 10up-toolkit to \`@wordpress/scripts\`.
- **CONTRIBUTING.md** — dist output path is \`dist/popup.{js,css}\` (not the pre-wp-scripts \`dist/popup/\` subdirectory); same build-tool rename; the options page added to the no-build-step file list.
- **ROADMAP.md** — v0.8.x marked shipped; v0.9.x marked active and rewritten to capture what landed (account menu, options page, icon redesign, attribution, security hardening, build swap) and what is still pending (Apple bundle identifier change, final permissions review). The "Per-site overrides via a settings UI" out-of-scope note rewritten — the options page is shipped; only a per-site settings *page* (vs. the popup's toggles) remains out of scope.
- **SAFARI.md** — sync trigger list now includes \`options/*\`; adds a note on registering new top-level folders in the Xcode project file so the next maintainer doesn't hit the missing-folder-reference issue we hit shipping the options page.

No code changes; no test plan beyond reading the diffs.