### PR TITLE
Address post-review findings: Safari resources, plugin URI safety, stale comment

### DIFF
--- a/lib/early.js
+++ b/lib/early.js
@@ -7,8 +7,10 @@
  *
  * Only injects CSS if:
  *   - This origin is already known to be WordPress (in the cache), and
- *   - The user's preference for this origin is to hide the admin bar
- *     (default is hidden).
+ *   - The user has explicitly opted to hide the admin bar for this
+ *     origin (or has set the global "Hide admin bar by default" toggle
+ *     on the options page). The default behavior is to show the admin
+ *     bar — anything else requires an explicit pref.
  *
  * Safe to fail silently — content.js at document_idle will reconcile.
  */

--- a/lib/site-info.js
+++ b/lib/site-info.js
@@ -65,7 +65,7 @@
 				name: p.name || null,
 				version: p.version || null,
 				active: p.status === 'active',
-				pluginUri: p.plugin_uri || null,
+				pluginUri: safePluginUri(p.plugin_uri),
 			};
 			bySlug.set(slug, row);
 		}
@@ -80,6 +80,19 @@
 			return '';
 		}
 		return s.replace(/<[^>]*>/g, '').trim();
+	}
+
+	// REST returns whatever the plugin author wrote in their Plugin URI header.
+	// Reject anything that isn't http(s) so a malicious plugin can't smuggle a
+	// javascript: or data: URL through to chrome.tabs.create. SiteInfoPanel
+	// falls back to wordpress.org/plugins/{slug}/ when this returns null.
+	function safePluginUri(uri) {
+		if (typeof uri !== 'string' || !uri) return null;
+		try {
+			const protocol = new URL(uri).protocol;
+			if (protocol === 'http:' || protocol === 'https:') return uri;
+		} catch (_) { /* malformed URL */ }
+		return null;
 	}
 
 	const api = { mergePlugins, mergeTheme, stripTags };

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/options/options.css
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/options/options.css
@@ -1,0 +1,131 @@
+:root {
+	color-scheme: light dark;
+	--wpd-text: #1e1e1e;
+	--wpd-text-muted: #5a5a5a;
+	--wpd-bg: #ffffff;
+	--wpd-surface: #f6f7f7;
+	--wpd-border: #dcdcde;
+	--wpd-accent: #2271b1;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--wpd-text: #e4e4e7;
+		--wpd-text-muted: #a1a1aa;
+		--wpd-bg: #1e1e1e;
+		--wpd-surface: #2a2a2a;
+		--wpd-border: #3f3f46;
+	}
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+	margin: 0;
+	padding: 0;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+	background: var(--wpd-bg);
+	color: var(--wpd-text);
+	line-height: 1.5;
+}
+
+.wpd-options {
+	max-width: 640px;
+	margin: 0 auto;
+	padding: 32px 24px 48px;
+}
+
+.wpd-options__header {
+	margin-bottom: 24px;
+	padding-bottom: 16px;
+	border-bottom: 1px solid var(--wpd-border);
+}
+
+.wpd-options__header h1 {
+	margin: 0 0 4px;
+	font-size: 22px;
+	font-weight: 600;
+}
+
+.wpd-options__subtitle {
+	margin: 0;
+	color: var(--wpd-text-muted);
+	font-size: 14px;
+}
+
+.wpd-options__section {
+	margin-top: 24px;
+}
+
+.wpd-options__section h2 {
+	margin: 0 0 12px;
+	font-size: 14px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--wpd-text-muted);
+}
+
+.wpd-option {
+	display: flex;
+	gap: 12px;
+	padding: 16px;
+	background: var(--wpd-surface);
+	border: 1px solid var(--wpd-border);
+	border-radius: 8px;
+	cursor: pointer;
+}
+
+.wpd-option input[type="checkbox"] {
+	margin: 3px 0 0;
+	accent-color: var(--wpd-accent);
+	width: 16px;
+	height: 16px;
+}
+
+.wpd-option__label {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.wpd-option__title {
+	font-size: 14px;
+	font-weight: 500;
+}
+
+.wpd-option__hint {
+	font-size: 13px;
+	color: var(--wpd-text-muted);
+}
+
+.wpd-option--action {
+	align-items: center;
+	justify-content: space-between;
+}
+
+.wpd-button {
+	flex: 0 0 auto;
+	padding: 6px 12px;
+	font-size: 13px;
+	font-family: inherit;
+	color: var(--wpd-text);
+	background: var(--wpd-bg);
+	border: 1px solid var(--wpd-border);
+	border-radius: 6px;
+	cursor: pointer;
+}
+
+.wpd-button:hover {
+	border-color: var(--wpd-text-muted);
+}
+
+.wpd-options__status {
+	margin: 8px 4px 0;
+	min-height: 1em;
+	font-size: 13px;
+	color: var(--wpd-text-muted);
+}
+
+.wpd-options__status[data-tone="ok"] { color: #1a7f37; }
+.wpd-options__status[data-tone="error"] { color: #c4314b; }

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/options/options.html
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/options/options.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>WordPress Browser Extension — Options</title>
+	<link rel="stylesheet" href="options.css">
+</head>
+<body>
+	<main class="wpd-options">
+		<header class="wpd-options__header">
+			<h1>WordPress Browser Extension</h1>
+			<p class="wpd-options__subtitle">Browser-wide defaults. Per-site choices still live in the toolbar popup.</p>
+		</header>
+
+		<section class="wpd-options__section">
+			<h2>Admin bar</h2>
+			<label class="wpd-option">
+				<input type="checkbox" id="adminBarHiddenDefault">
+				<span class="wpd-option__label">
+					<span class="wpd-option__title">Hide admin bar by default</span>
+					<span class="wpd-option__hint">When enabled, the admin bar starts hidden on new WordPress sites. Per-site preferences in the popup still take precedence.</span>
+				</span>
+			</label>
+		</section>
+
+		<section class="wpd-options__section">
+			<h2>Experimental</h2>
+			<label class="wpd-option">
+				<input type="checkbox" id="siteInfoEnabled">
+				<span class="wpd-option__label">
+					<span class="wpd-option__title">Show site information panel</span>
+					<span class="wpd-option__hint">Adds a panel to the popup that surfaces the active theme, installed plugins, site name, and REST namespaces. Detection is heuristic — asset-path inference can produce duplicates and false positives (for example mu-plugins and drop-ins). Off by default.</span>
+				</span>
+			</label>
+		</section>
+
+		<section class="wpd-options__section">
+			<h2>Data</h2>
+			<div class="wpd-option wpd-option--action">
+				<div class="wpd-option__label">
+					<span class="wpd-option__title">Reset extension data</span>
+					<span class="wpd-option__hint">Clears every saved per-site preference, the global defaults set on this page, and the cached "is this a WordPress site" results. Useful for testing or starting fresh.</span>
+				</div>
+				<button type="button" id="resetData" class="wpd-button">Clear all data</button>
+			</div>
+			<p id="resetStatus" class="wpd-options__status" role="status" aria-live="polite"></p>
+		</section>
+	</main>
+	<script src="options.js"></script>
+</body>
+</html>

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/options/options.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/options/options.js
@@ -1,0 +1,75 @@
+/**
+ * Reads and writes the browser-wide defaults that live alongside the
+ * per-origin preferences in `wp_preferences_v1._global`. Per-origin
+ * values always win over these defaults; this page only affects sites
+ * the user has not explicitly toggled.
+ */
+const PREFS_KEY = 'wp_preferences_v1';
+const CACHE_KEY = 'wp_detection_cache_v1';
+const GLOBAL_NS = '_global';
+
+const adminBarToggle = document.getElementById('adminBarHiddenDefault');
+const siteInfoToggle = document.getElementById('siteInfoEnabled');
+const resetButton = document.getElementById('resetData');
+const resetStatus = document.getElementById('resetStatus');
+
+async function loadGlobalPrefs() {
+	try {
+		const data = await chrome.storage.local.get(PREFS_KEY);
+		return (data[PREFS_KEY] || {})[GLOBAL_NS] || {};
+	} catch (_) {
+		return {};
+	}
+}
+
+async function saveGlobalPref(key, value) {
+	try {
+		const data = await chrome.storage.local.get(PREFS_KEY);
+		const root = data[PREFS_KEY] || {};
+		const next = { ...(root[GLOBAL_NS] || {}), [key]: value };
+		await chrome.storage.local.set({ [PREFS_KEY]: { ...root, [GLOBAL_NS]: next } });
+	} catch (_) { /* storage write failed; UI stays unsynced until next reload */ }
+}
+
+(async () => {
+	const globalPrefs = await loadGlobalPrefs();
+	adminBarToggle.checked = globalPrefs.adminBarHidden === true;
+	siteInfoToggle.checked = globalPrefs.siteInfoEnabled === true;
+
+	adminBarToggle.addEventListener('change', () => {
+		saveGlobalPref('adminBarHidden', adminBarToggle.checked);
+	});
+
+	siteInfoToggle.addEventListener('change', () => {
+		saveGlobalPref('siteInfoEnabled', siteInfoToggle.checked);
+	});
+
+	// Reflect changes that arrive from another tab or context.
+	chrome.storage.onChanged.addListener((changes, area) => {
+		if (area !== 'local' || !changes[PREFS_KEY]) return;
+		const incoming = (changes[PREFS_KEY].newValue || {})[GLOBAL_NS] || {};
+		adminBarToggle.checked = incoming.adminBarHidden === true;
+		siteInfoToggle.checked = incoming.siteInfoEnabled === true;
+	});
+
+	resetButton.addEventListener('click', async () => {
+		const ok = window.confirm(
+			'Clear all extension data?\n\nThis removes every saved per-site preference, the global defaults on this page, and the cached WordPress detection results. Cannot be undone.',
+		);
+		if (!ok) return;
+		try {
+			await chrome.storage.local.remove([PREFS_KEY, CACHE_KEY]);
+			adminBarToggle.checked = false;
+			siteInfoToggle.checked = false;
+			resetStatus.textContent = 'Cleared.';
+			resetStatus.dataset.tone = 'ok';
+		} catch (_) {
+			resetStatus.textContent = 'Could not clear data. Try again.';
+			resetStatus.dataset.tone = 'error';
+		}
+		setTimeout(() => {
+			resetStatus.textContent = '';
+			delete resetStatus.dataset.tone;
+		}, 4000);
+	});
+})();

--- a/test/site-info.mjs
+++ b/test/site-info.mjs
@@ -63,5 +63,25 @@ console.log('\n[22] mergeTheme — REST overrides slug label');
 	assert(theme.version === '1.5', 'version surfaced');
 }
 
+console.log('\n[23] mergePlugins — plugin URI scheme validation');
+{
+	const restPlugins = [
+		{ plugin: 'good/good.php',  name: 'Good',   status: 'active', plugin_uri: 'https://example.com/plugin' },
+		{ plugin: 'http-ok/h.php',  name: 'HTTPOK', status: 'active', plugin_uri: 'http://legacy.example/plugin' },
+		{ plugin: 'evil/evil.php',  name: 'Evil',   status: 'active', plugin_uri: 'javascript:alert(1)' },
+		{ plugin: 'datauri/d.php',  name: 'Data',   status: 'active', plugin_uri: 'data:text/html,<h1>x</h1>' },
+		{ plugin: 'malformed/m.php',name: 'Mal',    status: 'active', plugin_uri: 'not-a-url' },
+		{ plugin: 'empty/e.php',    name: 'Empty',  status: 'active', plugin_uri: '' },
+	];
+	const rows = mergePlugins([], restPlugins, null);
+	const byName = Object.fromEntries(rows.map((r) => [r.name, r]));
+	assert(byName.Good.pluginUri === 'https://example.com/plugin',  'https plugin URI kept');
+	assert(byName.HTTPOK.pluginUri === 'http://legacy.example/plugin', 'http plugin URI kept');
+	assert(byName.Evil.pluginUri === null,   'javascript: scheme rejected');
+	assert(byName.Data.pluginUri === null,   'data: scheme rejected');
+	assert(byName.Mal.pluginUri === null,    'malformed URL rejected');
+	assert(byName.Empty.pluginUri === null,  'empty string yields null');
+}
+
 console.log(`\n${failures === 0 ? 'Site-info tests passed.' : failures + ' failure(s).'}`);
 process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Three small follow-ups from a read-only sweep against #18 / #20.

### 1. Safari Resources `options/` was left untracked (P1)

The Xcode project file (\`project.pbxproj\`) added in #18 references \`Resources/options/\`, but the three files inside that folder were never staged. A fresh clone hits the same "Unable to find options/options.html" error we saw before #18 fixed the Xcode side — just from the other direction. Stage them.

### 2. Plugin URI scheme validation (P2)

\`lib/site-info.js\` was happily forwarding whatever \`plugin_uri\` the REST response carried. That value comes from a plugin's own "Plugin URI" header — site-authored, and attacker-controllable when a site runs untrusted plugins. \`SiteInfoPanel\` then opened those URIs in new tabs.

Add \`safePluginUri()\` that rejects anything outside \`http:\` / \`https:\`. The existing \`wordpress.org/plugins/{slug}/\` fallback in \`SiteInfoPanel\` covers the rejected cases. A new \`[23]\` smoke scenario covers javascript:, data:, malformed, and empty.

### 3. Stale comment in \`lib/early.js\` (P3)

The header doc still said the admin bar default was hidden. The per-origin default flipped to shown in #17 and the global override landed in #18. Rewrite the paragraph so future maintainers don't follow the wrong mental model.

## Test plan

- [x] \`npm run build:safari\` — clean
- [x] \`npm test --prefix test\` — all green (existing scenarios + new [23])
- [ ] Fresh clone + \`npm install\` + open the Safari project in Xcode without running \`build:safari\` first — should no longer error on missing options page resources

Credit: findings from a Codex read-only sweep.