### PR TITLE
Add support for Chrome Extension Localization (i18n) using _locales

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,395 @@
+{
+  "ext_name": {
+    "message": "WordPress Browser Extension",
+    "description": "Extension name shown in browser UI"
+  },
+  "ext_short_name": {
+    "message": "WordPress",
+    "description": "Short name shown where space is limited"
+  },
+  "ext_description": {
+    "message": "Detect WordPress sites, jump to the editor, identify the host, toggle the admin bar, and more.",
+    "description": "Extension description shown in the browser's extension store and management pages"
+  },
+  "ext_action_title": {
+    "message": "WordPress Browser Extension",
+    "description": "Tooltip for the toolbar icon button"
+  },
+  "cmd_edit_this_page": {
+    "message": "Edit this page in WordPress",
+    "description": "Description for the keyboard shortcut command"
+  },
+
+  "options_page_title": {
+    "message": "WordPress Browser Extension — Options",
+    "description": "HTML page title for the options page"
+  },
+  "options_heading": {
+    "message": "WordPress Browser Extension",
+    "description": "H1 heading on the options page"
+  },
+  "options_subtitle": {
+    "message": "Browser-wide defaults. Per-site choices still live in the toolbar popup.",
+    "description": "Subtitle under the options page heading"
+  },
+  "options_admin_bar_section": {
+    "message": "Admin bar",
+    "description": "Section heading for admin bar settings"
+  },
+  "options_hide_admin_bar_label": {
+    "message": "Hide admin bar by default",
+    "description": "Toggle label for the hide-admin-bar option"
+  },
+  "options_hide_admin_bar_hint": {
+    "message": "When enabled, the admin bar starts hidden on new WordPress sites. Per-site preferences in the popup still take precedence.",
+    "description": "Hint text describing the hide-admin-bar toggle behavior"
+  },
+  "options_experimental_section": {
+    "message": "Experimental",
+    "description": "Section heading for experimental features"
+  },
+  "options_site_info_label": {
+    "message": "Show site information panel",
+    "description": "Toggle label for the site information panel option"
+  },
+  "options_site_info_hint": {
+    "message": "Adds a panel to the popup that surfaces the active theme, installed plugins, site name, and REST namespaces. Detection is heuristic — asset-path inference can produce duplicates and false positives (for example mu-plugins and drop-ins). Off by default.",
+    "description": "Hint text describing the site information panel feature"
+  },
+  "options_data_section": {
+    "message": "Data",
+    "description": "Section heading for data management settings"
+  },
+  "options_reset_label": {
+    "message": "Reset extension data",
+    "description": "Label for the reset/clear data option"
+  },
+  "options_reset_hint": {
+    "message": "Clears every saved per-site preference, the global defaults on this page, and the cached \"is this a WordPress site\" results. Useful for testing or starting fresh.",
+    "description": "Hint text describing what the reset action clears"
+  },
+  "options_clear_button": {
+    "message": "Clear all data",
+    "description": "Button label to trigger clearing all extension data"
+  },
+  "options_clear_confirm": {
+    "message": "Clear all extension data?\n\nThis removes every saved per-site preference, the global defaults on this page, and the cached WordPress detection results. Cannot be undone.",
+    "description": "Confirmation dialog text shown before clearing all data"
+  },
+  "options_cleared_success": {
+    "message": "Cleared.",
+    "description": "Status message shown after successfully clearing extension data"
+  },
+  "options_cleared_error": {
+    "message": "Could not clear data. Try again.",
+    "description": "Status message shown when clearing extension data fails"
+  },
+
+  "toolbar_title_detected": {
+    "message": "WordPress detected",
+    "description": "Toolbar icon tooltip when a WordPress site is detected but the user is not logged in"
+  },
+  "toolbar_title_detected_logged_in": {
+    "message": "WordPress detected — logged in",
+    "description": "Toolbar icon tooltip when a WordPress site is detected and the user is logged in"
+  },
+  "toolbar_title_default": {
+    "message": "WordPress Browser Extension",
+    "description": "Default toolbar icon tooltip when no WordPress site is detected"
+  },
+  "admin_bar_hidden_notice": {
+    "message": "[WordPress Browser Extension] Admin bar hidden on this site. Toggle \"Show Admin Bar\" in the extension popup or the options page.",
+    "description": "Console info message shown when the admin bar is hidden on a site"
+  },
+
+  "error_view_title": {
+    "message": "Something went wrong",
+    "description": "Title shown in the popup error state"
+  },
+  "error_view_description": {
+    "message": "Check the service-worker logs.",
+    "description": "Description shown in the popup error state"
+  },
+  "not_supported_title": {
+    "message": "Nothing to inspect here",
+    "description": "Title shown when the current tab cannot be inspected (e.g. new tab, browser pages)"
+  },
+  "not_supported_description": {
+    "message": "Open a website to get started.",
+    "description": "Description shown when the current tab cannot be inspected"
+  },
+  "not_wordpress_title": {
+    "message": "Not a WordPress site",
+    "description": "Title shown when the current site is not detected as WordPress"
+  },
+  "not_wordpress_description": {
+    "message": "No signals detected.",
+    "description": "Description shown when the current site is not detected as WordPress"
+  },
+
+  "verb_view": {
+    "message": "View",
+    "description": "Verb prefix for viewing a published post/page from the WP admin edit screen"
+  },
+  "verb_preview": {
+    "message": "Preview",
+    "description": "Verb prefix for previewing a draft post/page from the WP admin edit screen"
+  },
+  "visit_site": {
+    "message": "Visit Site",
+    "description": "Button label to visit the WordPress site's frontend"
+  },
+  "wordpress_admin": {
+    "message": "WordPress Admin",
+    "description": "Button label to open the WordPress admin dashboard"
+  },
+  "log_in": {
+    "message": "Log In",
+    "description": "Button label to log into a WordPress site"
+  },
+  "log_in_return": {
+    "message": "Log In, Return to Page",
+    "description": "Button label to log in and return to the current page"
+  },
+  "show_admin_bar": {
+    "message": "Show Admin Bar",
+    "description": "Toggle label to show/hide the WordPress admin bar"
+  },
+  "admin_bar_disabled_info": {
+    "message": "Admin bar appears to be disabled by your profile or theme, which limits this extension.",
+    "description": "Info text shown when the admin bar cannot be toggled due to profile or theme settings"
+  },
+  "check_profile_link": {
+    "message": "Check profile →",
+    "description": "Link text directing users to their WordPress profile settings"
+  },
+
+  "copy_url_label": {
+    "message": "Copy URL",
+    "description": "Aria-label and tooltip for the copy URL button"
+  },
+  "copied_label": {
+    "message": "Copied",
+    "description": "Aria-label and tooltip for the copy URL button after the URL has been copied"
+  },
+  "open_new_tab_label": {
+    "message": "Open in new tab",
+    "description": "Aria-label and tooltip for the open-in-new-tab button"
+  },
+
+  "account_menu_label": {
+    "message": "Account menu",
+    "description": "Aria-label for the user account menu button when no display name is available"
+  },
+  "account_menu_for_user": {
+    "message": "Account menu for $NAME$",
+    "description": "Aria-label for the user account menu button when a display name is available",
+    "placeholders": {
+      "name": { "content": "$1" }
+    }
+  },
+  "profile_menu_item": {
+    "message": "Profile",
+    "description": "Menu item linking to the user's WordPress profile"
+  },
+  "gravatar_menu_item": {
+    "message": "Gravatar",
+    "description": "Menu item linking to the user's Gravatar profile"
+  },
+  "log_out_button": {
+    "message": "Log Out",
+    "description": "Button label to log out of the WordPress site"
+  },
+  "confirm_click_button": {
+    "message": "Click again to confirm",
+    "description": "Button label shown after first click on a destructive action, prompting a second confirmation click"
+  },
+  "super_admin_role": {
+    "message": "Super Admin",
+    "description": "Role badge label for WordPress multisite super administrators"
+  },
+
+  "new_content_label": {
+    "message": "New",
+    "description": "Section label for the 'New content' action group in the popup"
+  },
+
+  "dev_tools_label": {
+    "message": "Developer Tools",
+    "description": "Section label for the developer tools group in the popup"
+  },
+  "highlight_blocks_toggle": {
+    "message": "Highlight Blocks",
+    "description": "Toggle label for the block highlighter developer tool"
+  },
+  "mobile_preview_action": {
+    "message": "Mobile Preview",
+    "description": "Action label to open the site in mobile preview mode"
+  },
+  "bypass_page_cache_action": {
+    "message": "Bypass Page Cache",
+    "description": "Action label to reload the page bypassing the server-side page cache"
+  },
+  "query_monitor_toggle": {
+    "message": "Query Monitor",
+    "description": "Toggle label for the Query Monitor plugin panel"
+  },
+  "clear_site_data_action": {
+    "message": "Clear Site Data (Keep Login)",
+    "description": "Action label to clear browser site data while preserving the login session"
+  },
+
+  "confirm_label": {
+    "message": "Confirm",
+    "description": "Default label for inline confirmation buttons"
+  },
+
+  "site_info_label": {
+    "message": "Site Information",
+    "description": "Section label for the site information panel"
+  },
+  "site_info_loading": {
+    "message": "Loading site information…",
+    "description": "Aria-live status text while site information is being fetched"
+  },
+  "active_theme_label": {
+    "message": "Active theme",
+    "description": "Label for the active theme row in the site information panel"
+  },
+  "plugins_label": {
+    "message": "Plugins",
+    "description": "Section label for the plugins group when the count is zero or unknown"
+  },
+  "plugins_with_count": {
+    "message": "Plugins ($COUNT$)",
+    "description": "Section label for plugins when the total count is known from REST",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "detected_plugins_with_count": {
+    "message": "Detected plugins ($COUNT$)",
+    "description": "Section label for plugins detected via DOM asset paths when REST count is unavailable",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "login_for_plugin_list": {
+    "message": "Log in for a comprehensive list of plugins with additional information.",
+    "description": "Hint shown in the plugins section when the user is logged out"
+  },
+  "nothing_detected": {
+    "message": "Nothing extra we could detect.",
+    "description": "Hint shown when no additional site information could be detected"
+  },
+  "login_for_info": {
+    "message": "Log in for additional information.",
+    "description": "Hint shown in the theme section when the user is logged out"
+  },
+
+  "update_singular": {
+    "message": "$COUNT$ update",
+    "description": "Status badge label for a single pending WordPress update",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "update_plural": {
+    "message": "$COUNT$ updates",
+    "description": "Status badge label for multiple pending WordPress updates",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "pending_comment_singular": {
+    "message": "$COUNT$ pending comment",
+    "description": "Status badge label for a single comment awaiting moderation",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "pending_comment_plural": {
+    "message": "$COUNT$ pending comments",
+    "description": "Status badge label for multiple comments awaiting moderation",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+
+  "edit_category": {
+    "message": "Edit Category",
+    "description": "Edit action label when viewing a category archive"
+  },
+  "edit_tag": {
+    "message": "Edit Tag",
+    "description": "Edit action label when viewing a tag archive"
+  },
+  "edit_term": {
+    "message": "Edit Term",
+    "description": "Edit action label when viewing a taxonomy term archive"
+  },
+  "edit_author": {
+    "message": "Edit Author",
+    "description": "Edit action label when viewing an author archive"
+  },
+  "edit_page_fallback": {
+    "message": "Edit Page",
+    "description": "Fallback edit action label when the post type cannot be determined"
+  },
+  "edit_archive_coming_soon": {
+    "message": "Edit Archive (Coming Soon)",
+    "description": "Disabled edit action label for archive pages not yet supported"
+  },
+  "edit_homepage_coming_soon": {
+    "message": "Edit Homepage (Coming Soon)",
+    "description": "Disabled edit action label for the homepage when not yet supported"
+  },
+  "edit_term_not_resolvable": {
+    "message": "Edit Term (Not Resolvable)",
+    "description": "Disabled edit action label when the term cannot be resolved to an edit URL"
+  },
+  "edit_author_not_resolvable": {
+    "message": "Edit Author (Not Resolvable)",
+    "description": "Disabled edit action label when the author cannot be resolved to an edit URL"
+  },
+  "nothing_to_edit": {
+    "message": "Nothing to Edit",
+    "description": "Disabled edit action label for pages with no editable content (e.g. search results, 404)"
+  },
+  "edit_post_type": {
+    "message": "Edit $TYPE$",
+    "description": "Edit action label prefixed with the post type name (e.g. 'Edit Post', 'Edit Page')",
+    "placeholders": {
+      "type": { "content": "$1" }
+    }
+  },
+
+  "post_type_post": {
+    "message": "Post",
+    "description": "Display name for the 'post' post type"
+  },
+  "post_type_page": {
+    "message": "Page",
+    "description": "Display name for the 'page' post type"
+  },
+  "post_type_media": {
+    "message": "Media",
+    "description": "Display name for the 'attachment' post type"
+  },
+  "post_type_block_pattern": {
+    "message": "Block Pattern",
+    "description": "Display name for the 'wp_block' post type (reusable blocks)"
+  },
+  "post_type_template": {
+    "message": "Template",
+    "description": "Display name for the 'wp_template' post type"
+  },
+  "post_type_template_part": {
+    "message": "Template Part",
+    "description": "Display name for the 'wp_template_part' post type"
+  },
+  "post_type_navigation_menu": {
+    "message": "Navigation Menu",
+    "description": "Display name for the 'wp_navigation' post type"
+  }
+}

--- a/background.js
+++ b/background.js
@@ -203,8 +203,8 @@ async function updateToolbar(tabId, isWordPress, context) {
   } catch (_) { /* icons not shipped yet */ }
 
   const title = isWordPress
-    ? `WordPress detected${context?.isLoggedIn ? ' — logged in' : ''}`
-    : 'WordPress Browser Extension';
+    ? chrome.i18n.getMessage(context?.isLoggedIn ? 'toolbar_title_detected_logged_in' : 'toolbar_title_detected') // "WordPress detected — logged in" / "WordPress detected"
+    : chrome.i18n.getMessage('toolbar_title_default'); // "WordPress Browser Extension"
   try {
     await chrome.action.setTitle({ tabId, title });
   } catch (_) { /* tab may have closed */ }

--- a/content.js
+++ b/content.js
@@ -76,7 +76,7 @@
         html.admin-bar, html.wp-toolbar { margin-top: 0 !important; --wp-admin--admin-bar--height: 0px !important; }
       `;
       document.documentElement.appendChild(hideStyle);
-      console.info('[WordPress Browser Extension] Admin bar hidden on this site. Toggle "Show Admin Bar" in the extension popup or the options page.');
+      console.info(chrome.i18n.getMessage('admin_bar_hidden_notice')); // "[WordPress Browser Extension] Admin bar hidden on this site. Toggle "Show Admin Bar" in the extension popup or the options page."
     }
     // Remove `body.admin-bar` so themes that key layout off it (e.g.
     // `body.admin-bar .header { padding-top: 32px }`) collapse cleanly

--- a/lib/early.js
+++ b/lib/early.js
@@ -56,7 +56,7 @@
     `;
     // documentElement exists even before <head>, so this is always safe.
     document.documentElement.appendChild(style);
-    console.info('[WordPress Browser Extension] Admin bar hidden on this site. Toggle "Show Admin Bar" in the extension popup or the options page.');
+    console.info(chrome.i18n.getMessage('admin_bar_hidden_notice')); // "[WordPress Browser Extension] Admin bar hidden on this site. Toggle "Show Admin Bar" in the extension popup or the options page."
   } catch (_) {
     // Storage unavailable or extension context invalidated — ignore.
   }

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,15 @@
 {
   "manifest_version": 3,
-  "name": "WordPress Browser Extension",
+  "name": "__MSG_ext_name__",
   "version": "0.9.0",
-  "short_name": "WordPress",
-  "description": "Detect WordPress sites, jump to the editor, identify the host, toggle the admin bar, and more.",
+  "short_name": "__MSG_ext_short_name__",
+  "description": "__MSG_ext_description__",
+  "default_locale": "en",
   "author": "Jake Goldman, Partner at Fueled",
   "homepage_url": "https://github.com/WordPress/browser-extension",
 
   "action": {
-    "default_title": "WordPress Browser Extension",
+    "default_title": "__MSG_ext_action_title__",
     "default_icon": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",
@@ -60,7 +61,7 @@
         "default": "Alt+Shift+E",
         "mac": "Alt+Shift+E"
       },
-      "description": "Edit this page in WordPress"
+      "description": "__MSG_cmd_edit_this_page__"
     }
   },
 

--- a/options/options.html
+++ b/options/options.html
@@ -2,46 +2,46 @@
 <html lang="en">
 <head>
 	<meta charset="UTF-8">
-	<title>WordPress Browser Extension — Options</title>
+	<title data-i18n="options_page_title">WordPress Browser Extension — Options</title>
 	<link rel="stylesheet" href="options.css">
 </head>
 <body>
 	<main class="wpd-options">
 		<header class="wpd-options__header">
-			<h1>WordPress Browser Extension</h1>
-			<p class="wpd-options__subtitle">Browser-wide defaults. Per-site choices still live in the toolbar popup.</p>
+			<h1 data-i18n="options_heading">WordPress Browser Extension</h1>
+			<p class="wpd-options__subtitle" data-i18n="options_subtitle">Browser-wide defaults. Per-site choices still live in the toolbar popup.</p>
 		</header>
 
 		<section class="wpd-options__section">
-			<h2>Admin bar</h2>
+			<h2 data-i18n="options_admin_bar_section">Admin bar</h2>
 			<label class="wpd-option">
 				<input type="checkbox" id="adminBarHiddenDefault">
 				<span class="wpd-option__label">
-					<span class="wpd-option__title">Hide admin bar by default</span>
-					<span class="wpd-option__hint">When enabled, the admin bar starts hidden on new WordPress sites. Per-site preferences in the popup still take precedence.</span>
+					<span class="wpd-option__title" data-i18n="options_hide_admin_bar_label">Hide admin bar by default</span>
+					<span class="wpd-option__hint" data-i18n="options_hide_admin_bar_hint">When enabled, the admin bar starts hidden on new WordPress sites. Per-site preferences in the popup still take precedence.</span>
 				</span>
 			</label>
 		</section>
 
 		<section class="wpd-options__section">
-			<h2>Experimental</h2>
+			<h2 data-i18n="options_experimental_section">Experimental</h2>
 			<label class="wpd-option">
 				<input type="checkbox" id="siteInfoEnabled">
 				<span class="wpd-option__label">
-					<span class="wpd-option__title">Show site information panel</span>
-					<span class="wpd-option__hint">Adds a panel to the popup that surfaces the active theme, installed plugins, site name, and REST namespaces. Detection is heuristic — asset-path inference can produce duplicates and false positives (for example mu-plugins and drop-ins). Off by default.</span>
+					<span class="wpd-option__title" data-i18n="options_site_info_label">Show site information panel</span>
+					<span class="wpd-option__hint" data-i18n="options_site_info_hint">Adds a panel to the popup that surfaces the active theme, installed plugins, site name, and REST namespaces. Detection is heuristic — asset-path inference can produce duplicates and false positives (for example mu-plugins and drop-ins). Off by default.</span>
 				</span>
 			</label>
 		</section>
 
 		<section class="wpd-options__section">
-			<h2>Data</h2>
+			<h2 data-i18n="options_data_section">Data</h2>
 			<div class="wpd-option wpd-option--action">
 				<div class="wpd-option__label">
-					<span class="wpd-option__title">Reset extension data</span>
-					<span class="wpd-option__hint">Clears every saved per-site preference, the global defaults set on this page, and the cached "is this a WordPress site" results. Useful for testing or starting fresh.</span>
+					<span class="wpd-option__title" data-i18n="options_reset_label">Reset extension data</span>
+					<span class="wpd-option__hint" data-i18n="options_reset_hint">Clears every saved per-site preference, the global defaults on this page, and the cached "is this a WordPress site" results. Useful for testing or starting fresh.</span>
 				</div>
-				<button type="button" id="resetData" class="wpd-button">Clear all data</button>
+				<button type="button" id="resetData" class="wpd-button" data-i18n="options_clear_button">Clear all data</button>
 			</div>
 			<p id="resetStatus" class="wpd-options__status" role="status" aria-live="polite"></p>
 		</section>

--- a/options/options.js
+++ b/options/options.js
@@ -4,6 +4,15 @@
  * values always win over these defaults; this page only affects sites
  * the user has not explicitly toggled.
  */
+
+function localizeUI() {
+	document.querySelectorAll('[data-i18n]').forEach((el) => {
+		const msg = chrome.i18n.getMessage(el.dataset.i18n);
+		if (msg) el.textContent = msg;
+	});
+}
+localizeUI();
+
 const PREFS_KEY = 'wp_preferences_v1';
 const CACHE_KEY = 'wp_detection_cache_v1';
 const GLOBAL_NS = '_global';
@@ -53,18 +62,16 @@ async function saveGlobalPref(key, value) {
 	});
 
 	resetButton.addEventListener('click', async () => {
-		const ok = window.confirm(
-			'Clear all extension data?\n\nThis removes every saved per-site preference, the global defaults on this page, and the cached WordPress detection results. Cannot be undone.',
-		);
+		const ok = window.confirm(chrome.i18n.getMessage('options_clear_confirm')); // "Clear all extension data?\n\nThis removes every saved per-site preference, the global defaults on this page, and the cached WordPress detection results. Cannot be undone."
 		if (!ok) return;
 		try {
 			await chrome.storage.local.remove([PREFS_KEY, CACHE_KEY]);
 			adminBarToggle.checked = false;
 			siteInfoToggle.checked = false;
-			resetStatus.textContent = 'Cleared.';
+			resetStatus.textContent = chrome.i18n.getMessage('options_cleared_success'); // "Cleared."
 			resetStatus.dataset.tone = 'ok';
 		} catch (_) {
-			resetStatus.textContent = 'Could not clear data. Try again.';
+			resetStatus.textContent = chrome.i18n.getMessage('options_cleared_error'); // "Could not clear data. Try again."
 			resetStatus.dataset.tone = 'error';
 		}
 		setTimeout(() => {

--- a/src/popup/components/ActionRow.js
+++ b/src/popup/components/ActionRow.js
@@ -59,8 +59,8 @@ export function ActionRow({
 							className={`wpd-card__aux-btn ${copied ? 'is-copied' : ''}`}
 							onClick={handleCopy}
 							disabled={disabled}
-							aria-label={copied ? 'Copied' : 'Copy URL'}
-							title={copied ? 'Copied' : 'Copy URL'}
+							aria-label={copied ? chrome.i18n.getMessage('copied_label') /* "Copied" */ : chrome.i18n.getMessage('copy_url_label') /* "Copy URL" */}
+							title={copied ? chrome.i18n.getMessage('copied_label') /* "Copied" */ : chrome.i18n.getMessage('copy_url_label') /* "Copy URL" */}
 						>
 							<Icon icon={copied ? check : copy} size={16} />
 						</button>
@@ -71,8 +71,8 @@ export function ActionRow({
 							className="wpd-card__aux-btn"
 							onClick={onNewTab}
 							disabled={disabled}
-							aria-label="Open in new tab"
-							title="Open in new tab"
+							aria-label={chrome.i18n.getMessage('open_new_tab_label') /* "Open in new tab" */}
+							title={chrome.i18n.getMessage('open_new_tab_label') /* "Open in new tab" */}
 						>
 							<Icon icon={external} size={16} />
 						</button>

--- a/src/popup/components/DetectedView.js
+++ b/src/popup/components/DetectedView.js
@@ -100,8 +100,8 @@ function WpAdminActions({ ctx, origin, url }) {
 		}
 	})();
 
-	const typeLabel = ctx.postType ? postTypeLabel(ctx.postType) : 'Page';
-	const verb = ctx.postStatus === 'publish' ? 'View' : 'Preview';
+	const typeLabel = ctx.postType ? postTypeLabel(ctx.postType) : chrome.i18n.getMessage('post_type_page'); // "Page"
+	const verb = chrome.i18n.getMessage(ctx.postStatus === 'publish' ? 'verb_view' : 'verb_preview'); // "View" / "Preview"
 
 	return (
 		<>
@@ -118,13 +118,13 @@ function WpAdminActions({ ctx, origin, url }) {
 			)}
 			<ActionRow
 				icon={globe}
-				label="Visit Site"
+				label={chrome.i18n.getMessage('visit_site') /* "Visit Site" */}
 				onClick={() => runAction('visit-site', { origin, url })}
 				onNewTab={() => runAction('visit-site', { origin, url, newTab: true })}
 			/>
 			<ActionRow
 				icon={dashboard}
-				label="WordPress Admin"
+				label={chrome.i18n.getMessage('wordpress_admin') /* "WordPress Admin" */}
 				onClick={() => runAction('admin', { origin, url })}
 				onNewTab={() => runAction('admin', { origin, url, newTab: true })}
 			/>
@@ -166,7 +166,7 @@ function FrontendLoggedInActions({ ctx, origin, url }) {
 			/>
 			<ActionRow
 				icon={dashboard}
-				label="WordPress Admin"
+				label={chrome.i18n.getMessage('wordpress_admin') /* "WordPress Admin" */}
 				onClick={() => runAction('admin', { origin, url })}
 				onNewTab={() => runAction('admin', { origin, url, newTab: true })}
 			/>
@@ -180,13 +180,13 @@ function LoggedOutActions({ origin, url }) {
 		<>
 			<ActionRow
 				icon={key}
-				label="Log In"
+				label={chrome.i18n.getMessage('log_in') /* "Log In" */}
 				onClick={() => runAction('login', { origin, url })}
 				onNewTab={() => runAction('login', { origin, url, newTab: true })}
 			/>
 			<ActionRow
 				icon={keyboardReturn}
-				label="Log In, Return to Page"
+				label={chrome.i18n.getMessage('log_in_return') /* "Log In, Return to Page" */}
 				onClick={() => runAction('login-return', { origin, url })}
 				onNewTab={() => runAction('login-return', { origin, url, newTab: true })}
 			/>
@@ -196,7 +196,7 @@ function LoggedOutActions({ origin, url }) {
 
 function AdminBarSection({ ctx, origin, prefs, onToggle }) {
 	if (ctx.hasAdminBar) {
-		return <ToggleRow icon={seen} label="Show Admin Bar" checked={!prefs.adminBarHidden} onChange={onToggle} />;
+		return <ToggleRow icon={seen} label={chrome.i18n.getMessage('show_admin_bar') /* "Show Admin Bar" */} checked={!prefs.adminBarHidden} onChange={onToggle} />;
 	}
 	// Logged-in but no admin bar — could be a profile preference, a theme
 	// filter (show_admin_bar(false) or unhooking wp_admin_bar_render), or
@@ -204,15 +204,15 @@ function AdminBarSection({ ctx, origin, prefs, onToggle }) {
 	// causes; "appears" hedges honestly across all cases.
 	return (
 		<>
-			<ToggleRow icon={seen} label="Show Admin Bar" checked={false} disabled />
+			<ToggleRow icon={seen} label={chrome.i18n.getMessage('show_admin_bar') /* "Show Admin Bar" */} checked={false} disabled />
 			<div className="wpd-toggle-hint">
-				Admin bar appears to be disabled by your profile or theme, which limits this extension.{' '}
+				{chrome.i18n.getMessage('admin_bar_disabled_info') /* "Admin bar appears to be disabled by your profile or theme, which limits this extension." */}{' '}
 				<button
 					type="button"
 					className="wpd-info-row__link"
 					onClick={() => runAction('profile', { origin, url: '' })}
 				>
-					Check profile →
+					{chrome.i18n.getMessage('check_profile_link') /* "Check profile →" */}
 				</button>
 			</div>
 		</>

--- a/src/popup/components/DevTools.js
+++ b/src/popup/components/DevTools.js
@@ -44,7 +44,7 @@ export function DevTools({ origin, url, hasQueryMonitor = false, qmOpen = false 
 			<Collapsible.Trigger className="wpd-devtools__trigger">
 				<span className="wpd-devtools__label-group">
 					<Icon icon={code} size={16} />
-					<span className="wpd-devtools__label">Developer Tools</span>
+					<span className="wpd-devtools__label">{chrome.i18n.getMessage('dev_tools_label') /* "Developer Tools" */}</span>
 				</span>
 				<span className={`wpd-devtools__chevron ${open ? 'is-open' : ''}`} aria-hidden="true">
 					<Icon icon={chevronDown} size={14} />
@@ -54,31 +54,31 @@ export function DevTools({ origin, url, hasQueryMonitor = false, qmOpen = false 
 				<div className="wpd-devtools__items">
 					<ToggleRow
 						icon={layout}
-						label="Highlight Blocks"
+						label={chrome.i18n.getMessage('highlight_blocks_toggle') /* "Highlight Blocks" */}
 						checked={!!prefs.blockInspectorEnabled}
 						onChange={toggleBlockInspector}
 					/>
 					<ActionRow
 						icon={mobile}
-						label="Mobile Preview"
+						label={chrome.i18n.getMessage('mobile_preview_action') /* "Mobile Preview" */}
 						onClick={() => runAction('mobile-preview', { origin, url })}
 					/>
 					<ActionRow
 						icon={update}
-						label="Bypass Page Cache"
+						label={chrome.i18n.getMessage('bypass_page_cache_action') /* "Bypass Page Cache" */}
 						onClick={() => runAction('cachebust', { origin, url })}
 					/>
 					{hasQueryMonitor && (
 						<ToggleRow
 							icon={search}
-							label="Query Monitor"
+							label={chrome.i18n.getMessage('query_monitor_toggle') /* "Query Monitor" */}
 							checked={qmChecked}
 							onChange={(next) => { setQmChecked(next); toggleQueryMonitor(); }}
 						/>
 					)}
 					<InlineConfirm
 						icon={trash}
-						label="Clear Site Data (Keep Login)"
+						label={chrome.i18n.getMessage('clear_site_data_action') /* "Clear Site Data (Keep Login)" */}
 						onConfirm={() => runAction('clear-data', { origin, url })}
 						destructive
 					/>

--- a/src/popup/components/ErrorView.js
+++ b/src/popup/components/ErrorView.js
@@ -7,8 +7,8 @@ export function ErrorView() {
 			<EmptyState.Visual>
 				<EmptyState.Icon icon={error} />
 			</EmptyState.Visual>
-			<EmptyState.Title>Something went wrong</EmptyState.Title>
-			<EmptyState.Description>Check the service-worker logs.</EmptyState.Description>
+			<EmptyState.Title>{chrome.i18n.getMessage('error_view_title') /* "Something went wrong" */}</EmptyState.Title>
+			<EmptyState.Description>{chrome.i18n.getMessage('error_view_description') /* "Check the service-worker logs." */}</EmptyState.Description>
 		</EmptyState.Root>
 	);
 }

--- a/src/popup/components/Header.js
+++ b/src/popup/components/Header.js
@@ -62,7 +62,7 @@ export function Header({
 					{updateCount > 0 && (
 						<StatusBadge
 							icon={update}
-							label={`${updateCount} ${updateCount === 1 ? 'update' : 'updates'}`}
+							label={chrome.i18n.getMessage(updateCount === 1 ? 'update_singular' : 'update_plural', [String(updateCount)]) /* "1 update" / "N updates" */}
 							intent="medium"
 							onClick={() => onOpen?.(`${origin}/wp-admin/update-core.php`)}
 						/>
@@ -70,7 +70,7 @@ export function Header({
 					{commentCount > 0 && (
 						<StatusBadge
 							icon={postComments}
-							label={`${commentCount} pending ${commentCount === 1 ? 'comment' : 'comments'}`}
+							label={chrome.i18n.getMessage(commentCount === 1 ? 'pending_comment_singular' : 'pending_comment_plural', [String(commentCount)]) /* "1 pending comment" / "N pending comments" */}
 							intent="informational"
 							onClick={() =>
 								onOpen?.(`${origin}/wp-admin/edit-comments.php?comment_status=moderated`)

--- a/src/popup/components/InlineConfirm.js
+++ b/src/popup/components/InlineConfirm.js
@@ -9,7 +9,7 @@ import { Button, Icon } from '@wordpress/ui';
 export function InlineConfirm({
 	icon,
 	label,
-	confirmLabel = 'Confirm',
+	confirmLabel = chrome.i18n.getMessage('confirm_label'), // "Confirm"
 	onConfirm,
 	revealMs = 10000,
 	destructive = false,

--- a/src/popup/components/NewContent.js
+++ b/src/popup/components/NewContent.js
@@ -26,7 +26,7 @@ export function NewContent({ items = [], onOpen }) {
 			<Collapsible.Trigger className="wpd-newcontent__trigger">
 				<span className="wpd-newcontent__label-group">
 					<Icon icon={plus} size={16} />
-					<span className="wpd-newcontent__label">New</span>
+					<span className="wpd-newcontent__label">{chrome.i18n.getMessage('new_content_label') /* "New" */}</span>
 				</span>
 				<span className={`wpd-newcontent__chevron ${open ? 'is-open' : ''}`} aria-hidden="true">
 					<Icon icon={chevronDown} size={14} />

--- a/src/popup/components/NotSupportedView.js
+++ b/src/popup/components/NotSupportedView.js
@@ -7,8 +7,8 @@ export function NotSupportedView() {
 			<EmptyState.Visual>
 				<EmptyState.Icon icon={globe} />
 			</EmptyState.Visual>
-			<EmptyState.Title>Nothing to inspect here</EmptyState.Title>
-			<EmptyState.Description>Open a website to get started.</EmptyState.Description>
+			<EmptyState.Title>{chrome.i18n.getMessage('not_supported_title') /* "Nothing to inspect here" */}</EmptyState.Title>
+			<EmptyState.Description>{chrome.i18n.getMessage('not_supported_description') /* "Open a website to get started." */}</EmptyState.Description>
 		</EmptyState.Root>
 	);
 }

--- a/src/popup/components/NotWordPressView.js
+++ b/src/popup/components/NotWordPressView.js
@@ -10,8 +10,8 @@ export function NotWordPressView({ hostname }) {
 				<EmptyState.Visual>
 					<EmptyState.Icon icon={info} />
 				</EmptyState.Visual>
-				<EmptyState.Title>Not a WordPress site</EmptyState.Title>
-				<EmptyState.Description>No signals detected.</EmptyState.Description>
+				<EmptyState.Title>{chrome.i18n.getMessage('not_wordpress_title') /* "Not a WordPress site" */}</EmptyState.Title>
+				<EmptyState.Description>{chrome.i18n.getMessage('not_wordpress_description') /* "No signals detected." */}</EmptyState.Description>
 			</EmptyState.Root>
 		</>
 	);

--- a/src/popup/components/SiteInfoPanel.js
+++ b/src/popup/components/SiteInfoPanel.js
@@ -77,7 +77,7 @@ export function SiteInfoPanel({ ctx, origin, onOpen }) {
 			<Collapsible.Trigger className="wpd-siteinfo__trigger">
 				<span className="wpd-siteinfo__label-group">
 					<Icon icon={infoIcon} size={16} />
-					<span className="wpd-siteinfo__label">Site Information</span>
+					<span className="wpd-siteinfo__label">{chrome.i18n.getMessage('site_info_label') /* "Site Information" */}</span>
 				</span>
 				<span
 					className={`wpd-siteinfo__chevron ${open ? 'is-open' : ''}`}
@@ -90,12 +90,12 @@ export function SiteInfoPanel({ ctx, origin, onOpen }) {
 				<div className="wpd-siteinfo__body">
 					{loading && (
 						<p className="wpd-siteinfo__hint wpd-siteinfo__hint--loading" aria-live="polite">
-							Loading site information…
+							{chrome.i18n.getMessage('site_info_loading') /* "Loading site information…" */}
 						</p>
 					)}
 
 					{!loading && themeInfo && (
-						<InfoGroup label="Active theme">
+						<InfoGroup label={chrome.i18n.getMessage('active_theme_label') /* "Active theme" */}>
 							<ThemeRow theme={themeInfo} origin={origin} onOpen={onOpen} />
 						</InfoGroup>
 					)}
@@ -111,14 +111,14 @@ export function SiteInfoPanel({ ctx, origin, onOpen }) {
 							)}
 							{attempted && !plugins && pluginRows.length > 0 && (
 								<p className="wpd-siteinfo__hint">
-									Log in for a comprehensive list of plugins with additional information.
+									{chrome.i18n.getMessage('login_for_plugin_list') /* "Log in for a comprehensive list of plugins with additional information." */}
 								</p>
 							)}
 						</InfoGroup>
 					)}
 
 					{!loading && attempted && !hasAnything && (
-						<p className="wpd-siteinfo__hint">Nothing extra we could detect.</p>
+						<p className="wpd-siteinfo__hint">{chrome.i18n.getMessage('nothing_detected') /* "Nothing extra we could detect." */}</p>
 					)}
 				</div>
 			</Collapsible.Panel>
@@ -128,12 +128,12 @@ export function SiteInfoPanel({ ctx, origin, onOpen }) {
 
 function pluginsPluginLabel(plugins, count) {
 	if (plugins) {
-		return `Plugins (${count})`;
+		return chrome.i18n.getMessage('plugins_with_count', [String(count)]); // "Plugins (N)"
 	}
 	if (count > 0) {
-		return `Detected plugins (${count})`;
+		return chrome.i18n.getMessage('detected_plugins_with_count', [String(count)]); // "Detected plugins (N)"
 	}
-	return 'Plugins';
+	return chrome.i18n.getMessage('plugins_label'); // "Plugins"
 }
 
 function InfoGroup({ label, children }) {
@@ -166,7 +166,7 @@ function ThemeRow({ theme, origin, onOpen }) {
 						{theme.author && <span>by {stripTags(theme.author)}</span>}
 					</>
 				) : (
-					<span>Log in for additional information.</span>
+					<span>{chrome.i18n.getMessage('login_for_info') /* "Log in for additional information." */}</span>
 				)}
 			</div>
 		</div>

--- a/src/popup/components/UserMenu.js
+++ b/src/popup/components/UserMenu.js
@@ -45,10 +45,12 @@ export function UserMenu({ avatarUrl, displayName, origin, url, logoutUrl, editP
 
 	// Super admin wins. On multisite a super admin's per-site role is
 	// commonly just 'subscriber', so REST would mislabel them.
-	const roleLabel = isSuperAdmin ? 'Super Admin' : restRole;
+	const roleLabel = isSuperAdmin ? chrome.i18n.getMessage('super_admin_role') /* "Super Admin" */ : restRole;
 
 	const profileUrl = safeProfileUrl(editProfileUrl, origin);
-	const buttonLabel = displayName ? `Account menu for ${displayName}` : 'Account menu';
+	const buttonLabel = displayName
+		? chrome.i18n.getMessage('account_menu_for_user', [displayName]) // "Account menu for {name}"
+		: chrome.i18n.getMessage('account_menu_label'); // "Account menu"
 	// Admin bar avatars from gravatar.com carry the user's hash in the path.
 	// Custom-avatar plugins (User Profile Picture, etc.) point at an upload
 	// on the site's own host and won't match — we hide the menu item then.
@@ -97,7 +99,7 @@ export function UserMenu({ avatarUrl, displayName, origin, url, logoutUrl, editP
 				sideOffset={8}
 			>
 				<VisuallyHidden>
-					<Popover.Title>Account menu</Popover.Title>
+					<Popover.Title>{chrome.i18n.getMessage('account_menu_label') /* "Account menu" */}</Popover.Title>
 				</VisuallyHidden>
 				<div className="wpd-user-menu__dropdown" role="menu">
 					{displayName && (
@@ -110,7 +112,7 @@ export function UserMenu({ avatarUrl, displayName, origin, url, logoutUrl, editP
 					)}
 					<MenuLink
 						icon={people}
-						label="Profile"
+						label={chrome.i18n.getMessage('profile_menu_item') /* "Profile" */}
 						onClick={() => {
 							chrome.tabs.update({ url: profileUrl });
 							window.close();
@@ -119,7 +121,7 @@ export function UserMenu({ avatarUrl, displayName, origin, url, logoutUrl, editP
 					{gravatarProfileUrl && (
 						<MenuLink
 							icon={image}
-							label="Gravatar"
+							label={chrome.i18n.getMessage('gravatar_menu_item') /* "Gravatar" */}
 							onClick={() => {
 								chrome.tabs.create({ url: gravatarProfileUrl });
 								window.close();
@@ -136,7 +138,7 @@ export function UserMenu({ avatarUrl, displayName, origin, url, logoutUrl, editP
 							<Icon icon={login} size={16} />
 						</span>
 						<span className="wpd-user-menu__item-label">
-							{confirmingLogout ? 'Click again to confirm' : 'Log Out'}
+							{confirmingLogout ? chrome.i18n.getMessage('confirm_click_button') /* "Click again to confirm" */ : chrome.i18n.getMessage('log_out_button') /* "Log Out" */}
 						</span>
 					</button>
 				</div>

--- a/src/popup/lib/labels.js
+++ b/src/popup/lib/labels.js
@@ -5,22 +5,22 @@
 export function editLabel(ctx, editable) {
 	if (!editable) return editDisabledLabel(ctx);
 	if (ctx.pageType === 'term') {
-		if (ctx.taxonomy === 'category') return 'Edit Category';
-		if (ctx.taxonomy === 'post_tag') return 'Edit Tag';
-		return 'Edit Term';
+		if (ctx.taxonomy === 'category') return chrome.i18n.getMessage('edit_category'); // "Edit Category"
+		if (ctx.taxonomy === 'post_tag') return chrome.i18n.getMessage('edit_tag'); // "Edit Tag"
+		return chrome.i18n.getMessage('edit_term'); // "Edit Term"
 	}
-	if (ctx.pageType === 'author') return 'Edit Author';
-	if (ctx.postType) return `Edit ${postTypeLabel(ctx.postType)}`;
-	return 'Edit Page';
+	if (ctx.pageType === 'author') return chrome.i18n.getMessage('edit_author'); // "Edit Author"
+	if (ctx.postType) return chrome.i18n.getMessage('edit_post_type', [postTypeLabel(ctx.postType)]); // "Edit {Post|Page|…}"
+	return chrome.i18n.getMessage('edit_page_fallback'); // "Edit Page"
 }
 
 export function editDisabledLabel(ctx) {
-	if (ctx.pageType === 'archive') return 'Edit Archive (Coming Soon)';
-	if (ctx.pageType === 'home') return 'Edit Homepage (Coming Soon)';
-	if (ctx.pageType === 'term') return 'Edit Term (Not Resolvable)';
-	if (ctx.pageType === 'author') return 'Edit Author (Not Resolvable)';
-	if (ctx.pageType === 'search' || ctx.pageType === '404') return 'Nothing to Edit';
-	return 'Edit Page';
+	if (ctx.pageType === 'archive') return chrome.i18n.getMessage('edit_archive_coming_soon'); // "Edit Archive (Coming Soon)"
+	if (ctx.pageType === 'home') return chrome.i18n.getMessage('edit_homepage_coming_soon'); // "Edit Homepage (Coming Soon)"
+	if (ctx.pageType === 'term') return chrome.i18n.getMessage('edit_term_not_resolvable'); // "Edit Term (Not Resolvable)"
+	if (ctx.pageType === 'author') return chrome.i18n.getMessage('edit_author_not_resolvable'); // "Edit Author (Not Resolvable)"
+	if (ctx.pageType === 'search' || ctx.pageType === '404') return chrome.i18n.getMessage('nothing_to_edit'); // "Nothing to Edit"
+	return chrome.i18n.getMessage('edit_page_fallback'); // "Edit Page"
 }
 
 /**
@@ -33,19 +33,19 @@ export function editDisabledLabel(ctx) {
 export function postTypeLabel(postType) {
 	switch (postType) {
 		case 'post':
-			return 'Post';
+			return chrome.i18n.getMessage('post_type_post'); // "Post"
 		case 'page':
-			return 'Page';
+			return chrome.i18n.getMessage('post_type_page'); // "Page"
 		case 'attachment':
-			return 'Media';
+			return chrome.i18n.getMessage('post_type_media'); // "Media"
 		case 'wp_block':
-			return 'Block Pattern';
+			return chrome.i18n.getMessage('post_type_block_pattern'); // "Block Pattern"
 		case 'wp_template':
-			return 'Template';
+			return chrome.i18n.getMessage('post_type_template'); // "Template"
 		case 'wp_template_part':
-			return 'Template Part';
+			return chrome.i18n.getMessage('post_type_template_part'); // "Template Part"
 		case 'wp_navigation':
-			return 'Navigation Menu';
+			return chrome.i18n.getMessage('post_type_navigation_menu'); // "Navigation Menu"
 		default:
 			return postType.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 	}


### PR DESCRIPTION
This pull request adds support for Chrome Extension Internationalization (i18n) by implementing the _locales directory and replacing hardcoded strings with localized message references, which will help to add new languages to be added easily in the future for the chrome extension.

Fixes: https://github.com/WordPress/browser-extension/issues/28