### PR TITLE
Guard edit-this-page navigation against a closed tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -259,7 +259,13 @@ chrome.commands.onCommand.addListener(async (command) => {
   }
 
   if (editUrl) {
-    chrome.tabs.update(tab.id, { url: editUrl });
+    // Await + guard: the active tab can close or navigate between resolving
+    // the edit URL (which may involve an async REST round-trip above) and this
+    // navigation. A fire-and-forget update against a gone tab surfaces an
+    // "Unchecked runtime.lastError: No tab with id" in the service worker.
+    try {
+      await chrome.tabs.update(tab.id, { url: editUrl });
+    } catch (_) { /* tab closed before we could navigate it */ }
   }
 });
 

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
@@ -259,7 +259,13 @@ chrome.commands.onCommand.addListener(async (command) => {
   }
 
   if (editUrl) {
-    chrome.tabs.update(tab.id, { url: editUrl });
+    // Await + guard: the active tab can close or navigate between resolving
+    // the edit URL (which may involve an async REST round-trip above) and this
+    // navigation. A fire-and-forget update against a gone tab surfaces an
+    // "Unchecked runtime.lastError: No tab with id" in the service worker.
+    try {
+      await chrome.tabs.update(tab.id, { url: editUrl });
+    } catch (_) { /* tab closed before we could navigate it */ }
   }
 });
 


### PR DESCRIPTION
Fixes #37.

## Problem

The service worker logs `Unchecked runtime.lastError: No tab with id: <id>` (Context: Unknown, stack `:0 (anonymous function)`), surfacing a red **Errors** badge on the extension card. Cosmetic, but accumulates over a session.

## Root cause

The `edit-this-page` command handler in `background.js` resolves an edit URL — sometimes via an async REST round-trip (`RESOLVE_EDIT_URL_REST`) — then navigates with a **fire-and-forget** `chrome.tabs.update(tab.id, { url: editUrl })`. If the active tab closes or navigates away between resolving the URL and that call, the update rejects unobserved and Chrome logs the unchecked `runtime.lastError`.

I audited every `chrome.tabs/action/scripting` call in `background.js`: this is the **only** unguarded one. The toolbar `chrome.action.setIcon` / `setTitle` calls in `updateToolbar` are already `await` + `try/catch`, so their rejections are caught — they are **not** a source and are intentionally left unchanged (a pre-emptive `chrome.tabs.get` existence check there would add an API call on every `tabs.onUpdated` event for no real benefit, and introduce a check-then-use race).

## Fix

`await` the `chrome.tabs.update(...)` inside a `try/catch`, mirroring the existing `sendMessage` guards a few lines above in the same handler.

```js
if (editUrl) {
  try {
    await chrome.tabs.update(tab.id, { url: editUrl });
  } catch (_) { /* tab closed before we could navigate it */ }
}
```

## Testing

- `node --check background.js` passes.
- `cd test && npm test` (smoke + site-info) passes — unaffected, run for safety.
- Mirrored into the Safari `Resources/` via `scripts/sync-safari.sh` (background-only change; the popup bundle is untouched).