### PR TITLE
Consume runtime.lastError from updateToolbar setIcon/setTitle (#37)

### DIFF
--- a/background.js
+++ b/background.js
@@ -184,6 +184,15 @@ async function handleDetection(msg, sender) {
 
 // --- Toolbar icon + title -------------------------------------------------
 
+// chrome.action.setIcon resolves its promise even when the target tab has
+// closed or navigated away — it reports the failure as an unchecked
+// chrome.runtime.lastError instead, so an awaited try/catch never catches it
+// and it surfaces a red "Errors" badge on the extension card. (setTitle does
+// reject and could be awaited, but both use the callback form so each consumes
+// its own lastError.) updateToolbar runs on every tabs.onUpdated tick, exactly
+// when a tab can vanish mid-navigation; a missing tab here is expected.
+const ignoreLastError = () => void chrome.runtime.lastError;
+
 async function updateToolbar(tabId, isWordPress, context) {
   // Three states: not WP (gray + slash), WP but not logged in (gray),
   // WP + logged in (blue). The cache doesn't carry isLoggedIn so on a
@@ -192,22 +201,18 @@ async function updateToolbar(tabId, isWordPress, context) {
   const variant = !isWordPress ? '-inactive'
     : context?.isLoggedIn ? '-active'
     : '';
-  try {
-    await chrome.action.setIcon({
-      tabId,
-      path: {
-        16: `icons/icon-16${variant}.png`,
-        32: `icons/icon-32${variant}.png`,
-      },
-    });
-  } catch (_) { /* icons not shipped yet */ }
+  chrome.action.setIcon({
+    tabId,
+    path: {
+      16: `icons/icon-16${variant}.png`,
+      32: `icons/icon-32${variant}.png`,
+    },
+  }, ignoreLastError);
 
   const title = isWordPress
     ? `WordPress detected${context?.isLoggedIn ? ' — logged in' : ''}`
     : 'WordPress Browser Extension';
-  try {
-    await chrome.action.setTitle({ tabId, title });
-  } catch (_) { /* tab may have closed */ }
+  chrome.action.setTitle({ tabId, title }, ignoreLastError);
 }
 
 // --- Keyboard shortcut: edit this page ------------------------------------

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
@@ -184,6 +184,15 @@ async function handleDetection(msg, sender) {
 
 // --- Toolbar icon + title -------------------------------------------------
 
+// chrome.action.setIcon resolves its promise even when the target tab has
+// closed or navigated away — it reports the failure as an unchecked
+// chrome.runtime.lastError instead, so an awaited try/catch never catches it
+// and it surfaces a red "Errors" badge on the extension card. (setTitle does
+// reject and could be awaited, but both use the callback form so each consumes
+// its own lastError.) updateToolbar runs on every tabs.onUpdated tick, exactly
+// when a tab can vanish mid-navigation; a missing tab here is expected.
+const ignoreLastError = () => void chrome.runtime.lastError;
+
 async function updateToolbar(tabId, isWordPress, context) {
   // Three states: not WP (gray + slash), WP but not logged in (gray),
   // WP + logged in (blue). The cache doesn't carry isLoggedIn so on a
@@ -192,22 +201,18 @@ async function updateToolbar(tabId, isWordPress, context) {
   const variant = !isWordPress ? '-inactive'
     : context?.isLoggedIn ? '-active'
     : '';
-  try {
-    await chrome.action.setIcon({
-      tabId,
-      path: {
-        16: `icons/icon-16${variant}.png`,
-        32: `icons/icon-32${variant}.png`,
-      },
-    });
-  } catch (_) { /* icons not shipped yet */ }
+  chrome.action.setIcon({
+    tabId,
+    path: {
+      16: `icons/icon-16${variant}.png`,
+      32: `icons/icon-32${variant}.png`,
+    },
+  }, ignoreLastError);
 
   const title = isWordPress
     ? `WordPress detected${context?.isLoggedIn ? ' — logged in' : ''}`
     : 'WordPress Browser Extension';
-  try {
-    await chrome.action.setTitle({ tabId, title });
-  } catch (_) { /* tab may have closed */ }
+  chrome.action.setTitle({ tabId, title }, ignoreLastError);
 }
 
 // --- Keyboard shortcut: edit this page ------------------------------------


### PR DESCRIPTION
Follow-up to #38, addressing the second half of #37.

## Problem

`updateToolbar` in `background.js` is the dominant source of the `Unchecked runtime.lastError: No tab with id: <id>` warnings (the red **Errors** badge on the extension card). It runs on every `chrome.tabs.onUpdated` tick — the issue's "most reliable trigger" — exactly when a tab can close or navigate away mid-flight.

#38 fixes the `edit-this-page` `chrome.tabs.update` call, but deliberately leaves `updateToolbar` alone on the premise that its `await` + `try/catch` already catches the failure. That holds for `setTitle` but **not** for `setIcon`.

## Verification

Probed both calls against a non-existent tab id in the service-worker console (same `No tab with id` failure as a tab that closed mid-flight), mirroring `updateToolbar`'s awaited `try/catch`:

```
[T] setIcon resolved, no throw
Unchecked runtime.lastError: No tab with id: 2000000000.
[T] setTitle threw (caught): No tab with id: 2000000000.
```

`chrome.action.setIcon` **resolves** its promise on a missing tab and reports the failure as an unchecked `runtime.lastError` instead, so the awaited `try/catch` never sees it. `setTitle` does reject and is caught. So the existing guard only ever covered `setTitle`.

## Fix

Switch `setIcon`/`setTitle` to the callback form and read `chrome.runtime.lastError` to consume it, treating a missing tab as the expected outcome of the race. One change covers every caller (`onUpdated`, `repaintAllTabs`, `handleDetection`, `handlePopupResolution`).

Rejected the `chrome.tabs.get(tabId)` pre-check alternative from the issue: it's TOCTOU-racy (the tab can still close between the check and the call) and adds an API round-trip to a per-navigation listener.

## Testing

- `node --check background.js` passes.
- `cd test && npm test` (smoke + site-info) passes — unaffected, run for safety.
- Mirrored into the Safari `Resources/` via `scripts/sync-safari.sh` (background-only change; popup bundle untouched).
- Re-ran the SW-console probe with the callback form: no unchecked `lastError`.

Once this and #38 are both merged, #37 is fully resolved. (Issue #37 auto-closes via #38's closing keyword — merge this one first, then #38, so the close lands with both in.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)