### PR TITLE
Ignore the safari-build/ Xcode output directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ safari/**/xcuserdata/
 safari/**/*.xcuserstate
 safari/**/DerivedData/
 safari/**/build/
+# Xcode build output (DerivedData/intermediates) when the Safari project is
+# built with its output directory set here — generated, never committed
+safari-build/
 # local migration scratch — referenced during the transfer to
 # WordPress/browser-extension; not shipped to either repo
 .transfer/


### PR DESCRIPTION
## Problem

`safari-build/` — the Xcode DerivedData/intermediates output directory for the Safari project (`Build/`, `ModuleCache.noindex/`, `Logs/`, etc.) — was untracked but **not** gitignored. A `git add -A` sweeps ~300 build-artifact files into the commit. The existing `safari/**/{DerivedData,build}/` rules only cover the committed Xcode project under `safari/`, not this top-level sibling output dir.

## Fix

Add `safari-build/` to `.gitignore`. Nothing under it is currently tracked, so this only prevents accidental future commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)