### PR TITLE
Fix dev preview crash on logged-in DetectedView states (#53)

### DIFF
--- a/src/popup/preview.js
+++ b/src/popup/preview.js
@@ -44,6 +44,10 @@ window.WPRest = {
 	resolveEditUrlSync: (ctx, origin) =>
 		ctx.postId ? `${origin}/wp-admin/post.php?post=${ctx.postId}&action=edit` : null,
 	canResolveViaRest: (ctx) => !!ctx.postSlug,
+	// Mirrors lib/rest.js isTemplateBackedPage — pure, no backend needed.
+	// DetectedView calls this during render; without it the logged-in
+	// front-end fixtures throw and render blank (#53).
+	isTemplateBackedPage: (ctx) => ctx.pageType === 'home' || ctx.pageType === 'archive',
 	// Capability gates default to "allowed" in the preview — the canned user
 	// above is a full administrator, so the real lib logic would agree.
 	canAccessAdmin: () => true,


### PR DESCRIPTION
Fixes #53.

## Problem

The dev preview harness (`popup/preview.html`) renders two of its eight fixtures blank — **"Logged in · front-end"** and **"Admin bar disabled in profile"** — with:

```
Uncaught TypeError: t.isTemplateBackedPage is not a function
```

`src/popup/preview.js` stubs `window.WPRest` for the harness, but the stub lagged behind `lib/rest.js`. `DetectedView` (via `useEditUrlResolution`) calls `WPRest.isTemplateBackedPage(ctx)` during render, and the stub never grew that method. With no error boundary around each fixture, the thrown TypeError blanks the whole cell.

Dev-tooling only — the shipped extension loads the real `lib/rest.js` and was never affected.

## Fix

Add `isTemplateBackedPage` to the stub, mirroring the pure `lib/rest.js` implementation (`pageType === 'home' || pageType === 'archive'`). One-line change to the preview entry; no runtime/bundle impact (the tracked `dist/popup.*` is unchanged).

## Testing

- `npm run build` → open `popup/preview.html`: all eight fixtures render, console is clean.
- `cd test && npm test` → smoke + site-info suites pass.