### PR TITLE
Fix: Clean up admin bar hide stylesheet and notice on logged-out pages

### DIFF
--- a/content.js
+++ b/content.js
@@ -115,9 +115,17 @@
   const isWpAdmin = /\/wp-admin(\/|$)/.test(location.pathname);
   if (detection.context.isLoggedIn && !isWpAdmin) {
     loadAdminBarPref().then((hidden) => {
-      if (hidden) applyHide();
-      else applyShow();
+      if (hidden) {
+        if (hideStyle) {  // already hidden
+          console.info(chrome.i18n.getMessage('admin_bar_hidden_notice'));
+        }
+        applyHide();
+      } else {
+        applyShow();
+      }
     });
+  } else {
+    applyShow();
   }
 
   // -- Block inspector -----------------------------------------------------

--- a/lib/early.js
+++ b/lib/early.js
@@ -64,7 +64,6 @@
     style.textContent = HIDE_CSS;
     // documentElement exists even before <head>, so this is always safe.
     document.documentElement.appendChild(style);
-    console.info(chrome.i18n.getMessage('admin_bar_hidden_notice')); // "[WordPress Browser Extension] Admin bar hidden on this site. Toggle "Show Admin Bar" in the extension popup or the options page."
   } catch (_) {
     // Storage unavailable or extension context invalidated — ignore.
   }


### PR DESCRIPTION
This PR resolves #55 

## Problem

When the **"Hide admin bar by default"** preference is enabled (either globally or for a specific site), visiting a known WordPress site where the user is currently **logged out** results in:
1. A redundant `<style id="wp-detective-adminbar-hide">` stylesheet remaining permanently in the DOM.
2. A warning notice being logged to the console: `[WordPress Browser Extension] Admin bar hidden on this site. Toggle "Show Admin Bar" in the extension popup...`.

This happens because:
* `early.js` runs at `document_start` and hides the admin bar to prevent page flash before the login status is known. It also immediately logs the console message. Which then leads to:
* `content.js` runs at `document_idle`. Since the user is logged out, the login check block is skipped entirely, meaning `applyShow()` is never called to clean up the stylesheet or prevent/reconcile the console output.

## Fix

1. **Clean up early-injected styles**: Added an `else` block to the admin bar visibility logic in `content.js` so that `applyShow()` is called if the user is logged out or browsing inside `wp-admin`. This ensures the style is cleaned up.
2. **Log at idle**: In `content.js`, if the user is confirmed to be logged in and the preference is set to hide the admin bar:
   - If the stylesheet was newly created, `applyHide()` logs the notice.
   - If the stylesheet was already injected by `early.js` i.e. it is already hidden, the notice is logged once manually in the idle check (Removed the notice from `early.js` login state is unknown at that moment).

## Testing
`cd test && npm test` passes -- unaffected, ran for safety.
Manually verified change.

https://github.com/user-attachments/assets/e9387f8e-6b3e-47ee-8800-47aa8297c5e2

## Use of AI Tools
Utilised Antigravity IDE - Gemini 3.5 Flash (Low) for identifying relevant code files. Final implementation was reviewed and tested by me.