### PR TITLE
Add opt-in default for "Always open List View" in the Block Editor (#32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Browser-wide defaults live on a separate options page, surfaced through the brow
 Current options:
 
 - **Hide admin bar by default** — Flips the per-site default for the admin bar toggle. Per-site choices in the popup always win over this default.
+- **Always open List View** — Sets your Block Editor "List View" preference to open by default on every WordPress site you sign into, the same change as turning it on yourself in Editor Preferences. Off by default; only ever turns the preference on, never off, and never touches the REST API or your other saved preferences directly — it dispatches through the editor's own preferences store so WordPress's own persistence does the save.
 - **Show site information panel (experimental)** — Adds a panel to the popup that surfaces the active theme, installed plugins, site name, and REST namespaces. Detection is heuristic and asset-path inference can produce duplicates or false positives, so it is off by default. Powered by the WP REST API for admins, with DOM-scanned slugs as a graceful fallback.
 - **Clear all data** — Wipes per-site preferences, the global defaults above, the cached WordPress detection results, and the saved My Sites list. Useful for testing or starting fresh.
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -44,6 +44,18 @@
     "message": "When enabled, the admin bar starts hidden on new WordPress sites. Per-site preferences in the popup still take precedence.",
     "description": "Hint text describing the hide-admin-bar toggle behavior"
   },
+  "options_editor_section": {
+    "message": "Block Editor",
+    "description": "Section heading for Block Editor settings"
+  },
+  "options_list_view_default_label": {
+    "message": "Always open List View",
+    "description": "Toggle label for the List View default option"
+  },
+  "options_list_view_default_hint": {
+    "message": "When enabled, sets your \"List View\" editor preference to open by default on every WordPress site you sign into — the same change as turning it on yourself in Editor Preferences. Off by default; only ever turns the preference on, never off.",
+    "description": "Hint text describing the List View default toggle behavior"
+  },
   "options_experimental_section": {
     "message": "Experimental",
     "description": "Section heading for experimental features"

--- a/background.js
+++ b/background.js
@@ -278,8 +278,20 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   // only accepted from a content script's own tab, never the popup.
   if (msg.type === 'ENSURE_LIST_VIEW_DEFAULT') {
     if (!sender.tab || !sender.tab.id) return;
+    const origin = originFromSender(sender);
     ensureListViewDefault(sender.tab.id)
-      .then(() => sendResponse({ ok: true }))
+      .then(async (applied) => {
+        // Only record the one-shot "don't touch this origin again" marker
+        // once the dispatch actually succeeded — an unrecorded miss (e.g.
+        // wp.data wasn't ready yet) stays eligible to retry on the next
+        // editor page load instead of silently giving up forever. Routed
+        // through mutatePref so it shares the serialized write chain with
+        // every other wp_preferences_v1 mutation (no read-modify-write race).
+        if (applied && origin) {
+          await mutatePref({ ns: origin, key: 'listViewDefaultApplied', value: true });
+        }
+        sendResponse({ ok: true, applied });
+      })
       .catch(() => sendResponse({ ok: false }));
     return true;
   }
@@ -324,9 +336,10 @@ function isExtensionPageSender(sender) {
 // JSON directly, so there's no risk of clobbering the user's other saved
 // preferences (dark mode, panel states, etc). Runs in the page's MAIN world
 // via chrome.scripting — content scripts can't reach page globals like
-// `window.wp` directly.
+// `window.wp` directly. Returns whether the dispatch actually ran (false
+// when wp.data / the preferences store weren't available).
 async function ensureListViewDefault(tabId) {
-  await chrome.scripting.executeScript({
+  const [{ result } = {}] = await chrome.scripting.executeScript({
     target: { tabId },
     world: 'MAIN',
     func: (scope, preferenceName) => {
@@ -341,6 +354,7 @@ async function ensureListViewDefault(tabId) {
     },
     args: [WPEditorPreferences.SCOPE, WPEditorPreferences.PREFERENCE_NAME],
   });
+  return result === true;
 }
 
 // Polls until the window accepts the requested size or closes. Safari ignores

--- a/background.js
+++ b/background.js
@@ -19,6 +19,11 @@ importScripts('lib/my-sites.js');
 // admin-URL priority chain and its same-origin guard.
 importScripts('lib/rest.js');
 
+// Editor-preferences constants (globalThis.WPEditorPreferences), shared with
+// content.js so the scope list can't drift between the read-side check there
+// and the write-side dispatch here.
+importScripts('lib/editor-preferences.js');
+
 // Detection results are cached one storage key per origin (wp_cache_<origin>)
 // rather than a single blob, so a page load reads and writes only its own
 // origin's entry instead of the whole browsing history, and concurrent writes
@@ -268,6 +273,17 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     return true;
   }
 
+  // Opt-in (#32): content.js only sends this after confirming, from the
+  // DOM-inlined preferences snapshot, that the preference isn't already on —
+  // only accepted from a content script's own tab, never the popup.
+  if (msg.type === 'ENSURE_LIST_VIEW_DEFAULT') {
+    if (!sender.tab || !sender.tab.id) return;
+    ensureListViewDefault(sender.tab.id)
+      .then(() => sendResponse({ ok: true }))
+      .catch(() => sendResponse({ ok: false }));
+    return true;
+  }
+
   // Early downgrade hint from lib/early.js at DOMContentLoaded (#59): the
   // icon painted from cache can claim logged-in for seconds before full
   // detection reports the logged-out DOM at document_idle. Content scripts
@@ -298,6 +314,33 @@ function isExtensionPageSender(sender) {
   } catch (_) {
     return false;
   }
+}
+
+// Turns on "Always open List View" for the current user by dispatching
+// through the Block Editor's own already-registered preferences store — the
+// same store update a click on that Editor Preferences toggle would cause.
+// WordPress's own debounced persistence (already wired with the correct
+// nonce) does the actual save; we never touch the REST API or the stored
+// JSON directly, so there's no risk of clobbering the user's other saved
+// preferences (dark mode, panel states, etc). Runs in the page's MAIN world
+// via chrome.scripting — content scripts can't reach page globals like
+// `window.wp` directly.
+async function ensureListViewDefault(tabId) {
+  await chrome.scripting.executeScript({
+    target: { tabId },
+    world: 'MAIN',
+    func: (scope, preferenceName) => {
+      try {
+        const dispatch = window.wp && window.wp.data && window.wp.data.dispatch('core/preferences');
+        if (!dispatch) return false;
+        dispatch.set(scope, preferenceName, true);
+        return true;
+      } catch (_) {
+        return false;
+      }
+    },
+    args: [WPEditorPreferences.SCOPE, WPEditorPreferences.PREFERENCE_NAME],
+  });
 }
 
 // Polls until the window accepts the requested size or closes. Safari ignores

--- a/content.js
+++ b/content.js
@@ -191,13 +191,27 @@
     return (prefsRoot._global || {}).listViewDefaultEnabled === true;
   }
 
+  // One-shot per origin — once we've successfully nudged it on, we never
+  // check again, even if the user later turns List View back off themselves.
+  // Without this, "not true" reads as "needs it" forever and fights that
+  // choice on every editor page load.
+  async function listViewDefaultAlreadyApplied() {
+    const prefsRoot = await loadPrefsRoot();
+    return !!(prefsRoot[location.origin] || {}).listViewDefaultApplied;
+  }
+
   if (isBlockEditorPage && globalThis.WPEditorPreferences) {
-    loadListViewDefaultPref().then((enabled) => {
+    loadListViewDefaultPref().then(async (enabled) => {
       if (!enabled) return;
+      if (await listViewDefaultAlreadyApplied()) return;
       const { readPersistedPreferences, needsListViewDefault } = globalThis.WPEditorPreferences;
       const serverData = readPersistedPreferences(document);
-      // Already set — most page loads once the account is primed — so skip
-      // the round trip to background.js entirely.
+      // Already true — most page loads once the account is primed — so skip
+      // the round trip to background.js. The one-shot marker itself is only
+      // ever written by background.js, after a dispatch it actually made
+      // succeeds (see ensureListViewDefault); this early-exit intentionally
+      // leaves it unset so a value that became true some other way doesn't
+      // get treated as "we already asserted it."
       if (!needsListViewDefault(serverData)) return;
       try {
         chrome.runtime.sendMessage({ type: 'ENSURE_LIST_VIEW_DEFAULT' }).catch(() => {});

--- a/content.js
+++ b/content.js
@@ -177,6 +177,34 @@
     });
   }
 
+  // -- List View default (Block Editor) -------------------------------------
+  // Opt-in (#32): turns on "Always open List View" for the current user,
+  // mirroring what clicking that toggle in Editor Preferences does. See
+  // lib/editor-preferences.js for why this reads the current value from the
+  // DOM instead of a REST call, and background.js for the MAIN-world
+  // dispatch that actually flips it (content scripts can't reach the page's
+  // `window.wp`).
+  const isBlockEditorPage = isWpAdmin && document.body.classList.contains('block-editor-page');
+
+  async function loadListViewDefaultPref() {
+    const prefsRoot = await loadPrefsRoot();
+    return (prefsRoot._global || {}).listViewDefaultEnabled === true;
+  }
+
+  if (isBlockEditorPage && globalThis.WPEditorPreferences) {
+    loadListViewDefaultPref().then((enabled) => {
+      if (!enabled) return;
+      const { readPersistedPreferences, needsListViewDefault } = globalThis.WPEditorPreferences;
+      const serverData = readPersistedPreferences(document);
+      // Already set — most page loads once the account is primed — so skip
+      // the round trip to background.js entirely.
+      if (!needsListViewDefault(serverData)) return;
+      try {
+        chrome.runtime.sendMessage({ type: 'ENSURE_LIST_VIEW_DEFAULT' }).catch(() => {});
+      } catch (_) { /* extension context invalidated */ }
+    });
+  }
+
   // -- Popup messaging -----------------------------------------------------
 
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/lib/editor-preferences.js
+++ b/lib/editor-preferences.js
@@ -1,0 +1,78 @@
+/**
+ * WordPress Browser Extension — Block Editor preferences helpers
+ *
+ * Backs the "Always open List View" option (#32). Modern WordPress persists
+ * Block Editor preferences (List View, distraction free, etc.) server-side in
+ * user meta — not browser localStorage — and inlines the current snapshot
+ * next to the `wp-preferences` script so `wp.data` can hydrate without an
+ * extra REST round trip:
+ *
+ *   ( function() {
+ *     var serverData = {"core":{"showListViewByDefault":false}};
+ *     var userId = "5";
+ *     var persistenceLayer = wp.preferencesPersistence.__unstableCreatePersistenceLayer(...);
+ *     ...
+ *   } )();
+ *
+ * (see wp_default_packages_inline_scripts() in WordPress core.) These helpers
+ * read that same snapshot from the DOM — content scripts can't reach page
+ * globals like `window.wp` directly — so content.js can decide, without any
+ * REST call of its own, whether the preference still needs to be turned on.
+ *
+ * The scope is a single shared `"core"` string, not one per editor surface:
+ * both the post editor and the site editor read/write
+ * `getPreference( "core", "showListViewByDefault" )` (see edit-post.js and
+ * edit-site.js in WordPress core) — there is no separate "core/edit-post" or
+ * "core/edit-site" scope for this preference.
+ */
+(function () {
+  'use strict';
+
+  const SCOPE = 'core';
+  const PREFERENCE_NAME = 'showListViewByDefault';
+
+  /**
+   * Extracts the inlined `serverData` preferences snapshot from a Document.
+   * Returns the parsed object, or null if no matching inline script is
+   * found or its contents aren't the expected shape (e.g. a brand-new
+   * account with no persisted prefs yet, where WordPress inlines `""`).
+   */
+  function readPersistedPreferences(doc) {
+    if (!doc || !doc.querySelectorAll) return null;
+
+    const scripts = doc.querySelectorAll('script:not([src])');
+    for (let i = 0; i < scripts.length; i++) {
+      const text = scripts[i].textContent || '';
+      if (!text.includes('__unstableCreatePersistenceLayer')) continue;
+
+      const match = text.match(/var\s+serverData\s*=\s*(\{[\s\S]*?\});\s*\n?\s*var\s+userId/);
+      if (!match) continue;
+
+      try {
+        return JSON.parse(match[1]);
+      } catch (_) {
+        continue; // malformed/unexpected shape — try the next script, if any
+      }
+    }
+    return null;
+  }
+
+  /**
+   * True unless `serverData` already has the preference set to `true` under
+   * the shared "core" scope. Missing data (null/not-yet-persisted) is
+   * treated as "needs it" — safe because the actual write is a `wp.data`
+   * dispatch that only turns the preference on, never off; a false positive
+   * here at worst repeats a no-op set, not a wrong value.
+   */
+  function needsListViewDefault(serverData) {
+    if (!serverData) return true;
+    return (serverData[SCOPE] || {})[PREFERENCE_NAME] !== true;
+  }
+
+  globalThis.WPEditorPreferences = {
+    SCOPE,
+    PREFERENCE_NAME,
+    readPersistedPreferences,
+    needsListViewDefault,
+  };
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,7 @@
     },
     {
       "matches": ["http://*/*", "https://*/*"],
-      "js": ["lib/detect.js", "lib/rest.js", "lib/host.js", "lib/block-inspector.js", "content.js"],
+      "js": ["lib/detect.js", "lib/rest.js", "lib/host.js", "lib/block-inspector.js", "lib/editor-preferences.js", "content.js"],
       "run_at": "document_idle",
       "all_frames": false
     }

--- a/options/options.html
+++ b/options/options.html
@@ -24,6 +24,17 @@
 		</section>
 
 		<section class="wpd-options__section">
+			<h2 data-i18n="options_editor_section">Block Editor</h2>
+			<label class="wpd-option">
+				<input type="checkbox" id="listViewDefaultEnabled">
+				<span class="wpd-option__label">
+					<span class="wpd-option__title" data-i18n="options_list_view_default_label">Always open List View</span>
+					<span class="wpd-option__hint" data-i18n="options_list_view_default_hint">When enabled, sets your "List View" editor preference to open by default on every WordPress site you sign into — the same change as turning it on yourself in Editor Preferences. Off by default; only ever turns the preference on, never off.</span>
+				</span>
+			</label>
+		</section>
+
+		<section class="wpd-options__section">
 			<h2 data-i18n="options_experimental_section">Experimental</h2>
 			<label class="wpd-option">
 				<input type="checkbox" id="siteInfoEnabled">

--- a/options/options.js
+++ b/options/options.js
@@ -17,6 +17,7 @@ const PREFS_KEY = 'wp_preferences_v1';
 const GLOBAL_NS = '_global';
 
 const adminBarToggle = document.getElementById('adminBarHiddenDefault');
+const listViewDefaultToggle = document.getElementById('listViewDefaultEnabled');
 const siteInfoToggle = document.getElementById('siteInfoEnabled');
 const resetButton = document.getElementById('resetData');
 const resetStatus = document.getElementById('resetStatus');
@@ -42,10 +43,15 @@ async function saveGlobalPref(key, value) {
 (async () => {
 	const globalPrefs = await loadGlobalPrefs();
 	adminBarToggle.checked = globalPrefs.adminBarHidden === true;
+	listViewDefaultToggle.checked = globalPrefs.listViewDefaultEnabled === true;
 	siteInfoToggle.checked = globalPrefs.siteInfoEnabled === true;
 
 	adminBarToggle.addEventListener('change', () => {
 		saveGlobalPref('adminBarHidden', adminBarToggle.checked);
+	});
+
+	listViewDefaultToggle.addEventListener('change', () => {
+		saveGlobalPref('listViewDefaultEnabled', listViewDefaultToggle.checked);
 	});
 
 	siteInfoToggle.addEventListener('change', () => {
@@ -57,6 +63,7 @@ async function saveGlobalPref(key, value) {
 		if (area !== 'local' || !changes[PREFS_KEY]) return;
 		const incoming = (changes[PREFS_KEY].newValue || {})[GLOBAL_NS] || {};
 		adminBarToggle.checked = incoming.adminBarHidden === true;
+		listViewDefaultToggle.checked = incoming.listViewDefaultEnabled === true;
 		siteInfoToggle.checked = incoming.siteInfoEnabled === true;
 	});
 
@@ -71,6 +78,7 @@ async function saveGlobalPref(key, value) {
 			// wp_devtools_open behind).
 			await chrome.storage.local.clear();
 			adminBarToggle.checked = false;
+			listViewDefaultToggle.checked = false;
 			siteInfoToggle.checked = false;
 			resetStatus.textContent = chrome.i18n.getMessage('options_cleared_success'); // "Cleared."
 			resetStatus.dataset.tone = 'ok';

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/_locales/en/messages.json
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/_locales/en/messages.json
@@ -44,6 +44,18 @@
     "message": "When enabled, the admin bar starts hidden on new WordPress sites. Per-site preferences in the popup still take precedence.",
     "description": "Hint text describing the hide-admin-bar toggle behavior"
   },
+  "options_editor_section": {
+    "message": "Block Editor",
+    "description": "Section heading for Block Editor settings"
+  },
+  "options_list_view_default_label": {
+    "message": "Always open List View",
+    "description": "Toggle label for the List View default option"
+  },
+  "options_list_view_default_hint": {
+    "message": "When enabled, sets your \"List View\" editor preference to open by default on every WordPress site you sign into — the same change as turning it on yourself in Editor Preferences. Off by default; only ever turns the preference on, never off.",
+    "description": "Hint text describing the List View default toggle behavior"
+  },
   "options_experimental_section": {
     "message": "Experimental",
     "description": "Section heading for experimental features"

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
@@ -19,6 +19,11 @@ importScripts('lib/my-sites.js');
 // admin-URL priority chain and its same-origin guard.
 importScripts('lib/rest.js');
 
+// Editor-preferences constants (globalThis.WPEditorPreferences), shared with
+// content.js so the scope list can't drift between the read-side check there
+// and the write-side dispatch here.
+importScripts('lib/editor-preferences.js');
+
 // Detection results are cached one storage key per origin (wp_cache_<origin>)
 // rather than a single blob, so a page load reads and writes only its own
 // origin's entry instead of the whole browsing history, and concurrent writes
@@ -268,6 +273,29 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     return true;
   }
 
+  // Opt-in (#32): content.js only sends this after confirming, from the
+  // DOM-inlined preferences snapshot, that the preference isn't already on —
+  // only accepted from a content script's own tab, never the popup.
+  if (msg.type === 'ENSURE_LIST_VIEW_DEFAULT') {
+    if (!sender.tab || !sender.tab.id) return;
+    const origin = originFromSender(sender);
+    ensureListViewDefault(sender.tab.id)
+      .then(async (applied) => {
+        // Only record the one-shot "don't touch this origin again" marker
+        // once the dispatch actually succeeded — an unrecorded miss (e.g.
+        // wp.data wasn't ready yet) stays eligible to retry on the next
+        // editor page load instead of silently giving up forever. Routed
+        // through mutatePref so it shares the serialized write chain with
+        // every other wp_preferences_v1 mutation (no read-modify-write race).
+        if (applied && origin) {
+          await mutatePref({ ns: origin, key: 'listViewDefaultApplied', value: true });
+        }
+        sendResponse({ ok: true, applied });
+      })
+      .catch(() => sendResponse({ ok: false }));
+    return true;
+  }
+
   // Early downgrade hint from lib/early.js at DOMContentLoaded (#59): the
   // icon painted from cache can claim logged-in for seconds before full
   // detection reports the logged-out DOM at document_idle. Content scripts
@@ -298,6 +326,35 @@ function isExtensionPageSender(sender) {
   } catch (_) {
     return false;
   }
+}
+
+// Turns on "Always open List View" for the current user by dispatching
+// through the Block Editor's own already-registered preferences store — the
+// same store update a click on that Editor Preferences toggle would cause.
+// WordPress's own debounced persistence (already wired with the correct
+// nonce) does the actual save; we never touch the REST API or the stored
+// JSON directly, so there's no risk of clobbering the user's other saved
+// preferences (dark mode, panel states, etc). Runs in the page's MAIN world
+// via chrome.scripting — content scripts can't reach page globals like
+// `window.wp` directly. Returns whether the dispatch actually ran (false
+// when wp.data / the preferences store weren't available).
+async function ensureListViewDefault(tabId) {
+  const [{ result } = {}] = await chrome.scripting.executeScript({
+    target: { tabId },
+    world: 'MAIN',
+    func: (scope, preferenceName) => {
+      try {
+        const dispatch = window.wp && window.wp.data && window.wp.data.dispatch('core/preferences');
+        if (!dispatch) return false;
+        dispatch.set(scope, preferenceName, true);
+        return true;
+      } catch (_) {
+        return false;
+      }
+    },
+    args: [WPEditorPreferences.SCOPE, WPEditorPreferences.PREFERENCE_NAME],
+  });
+  return result === true;
 }
 
 // Polls until the window accepts the requested size or closes. Safari ignores

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/content.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/content.js
@@ -177,6 +177,48 @@
     });
   }
 
+  // -- List View default (Block Editor) -------------------------------------
+  // Opt-in (#32): turns on "Always open List View" for the current user,
+  // mirroring what clicking that toggle in Editor Preferences does. See
+  // lib/editor-preferences.js for why this reads the current value from the
+  // DOM instead of a REST call, and background.js for the MAIN-world
+  // dispatch that actually flips it (content scripts can't reach the page's
+  // `window.wp`).
+  const isBlockEditorPage = isWpAdmin && document.body.classList.contains('block-editor-page');
+
+  async function loadListViewDefaultPref() {
+    const prefsRoot = await loadPrefsRoot();
+    return (prefsRoot._global || {}).listViewDefaultEnabled === true;
+  }
+
+  // One-shot per origin — once we've successfully nudged it on, we never
+  // check again, even if the user later turns List View back off themselves.
+  // Without this, "not true" reads as "needs it" forever and fights that
+  // choice on every editor page load.
+  async function listViewDefaultAlreadyApplied() {
+    const prefsRoot = await loadPrefsRoot();
+    return !!(prefsRoot[location.origin] || {}).listViewDefaultApplied;
+  }
+
+  if (isBlockEditorPage && globalThis.WPEditorPreferences) {
+    loadListViewDefaultPref().then(async (enabled) => {
+      if (!enabled) return;
+      if (await listViewDefaultAlreadyApplied()) return;
+      const { readPersistedPreferences, needsListViewDefault } = globalThis.WPEditorPreferences;
+      const serverData = readPersistedPreferences(document);
+      // Already true — most page loads once the account is primed — so skip
+      // the round trip to background.js. The one-shot marker itself is only
+      // ever written by background.js, after a dispatch it actually made
+      // succeeds (see ensureListViewDefault); this early-exit intentionally
+      // leaves it unset so a value that became true some other way doesn't
+      // get treated as "we already asserted it."
+      if (!needsListViewDefault(serverData)) return;
+      try {
+        chrome.runtime.sendMessage({ type: 'ENSURE_LIST_VIEW_DEFAULT' }).catch(() => {});
+      } catch (_) { /* extension context invalidated */ }
+    });
+  }
+
   // -- Popup messaging -----------------------------------------------------
 
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/lib/editor-preferences.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/lib/editor-preferences.js
@@ -1,0 +1,78 @@
+/**
+ * WordPress Browser Extension — Block Editor preferences helpers
+ *
+ * Backs the "Always open List View" option (#32). Modern WordPress persists
+ * Block Editor preferences (List View, distraction free, etc.) server-side in
+ * user meta — not browser localStorage — and inlines the current snapshot
+ * next to the `wp-preferences` script so `wp.data` can hydrate without an
+ * extra REST round trip:
+ *
+ *   ( function() {
+ *     var serverData = {"core":{"showListViewByDefault":false}};
+ *     var userId = "5";
+ *     var persistenceLayer = wp.preferencesPersistence.__unstableCreatePersistenceLayer(...);
+ *     ...
+ *   } )();
+ *
+ * (see wp_default_packages_inline_scripts() in WordPress core.) These helpers
+ * read that same snapshot from the DOM — content scripts can't reach page
+ * globals like `window.wp` directly — so content.js can decide, without any
+ * REST call of its own, whether the preference still needs to be turned on.
+ *
+ * The scope is a single shared `"core"` string, not one per editor surface:
+ * both the post editor and the site editor read/write
+ * `getPreference( "core", "showListViewByDefault" )` (see edit-post.js and
+ * edit-site.js in WordPress core) — there is no separate "core/edit-post" or
+ * "core/edit-site" scope for this preference.
+ */
+(function () {
+  'use strict';
+
+  const SCOPE = 'core';
+  const PREFERENCE_NAME = 'showListViewByDefault';
+
+  /**
+   * Extracts the inlined `serverData` preferences snapshot from a Document.
+   * Returns the parsed object, or null if no matching inline script is
+   * found or its contents aren't the expected shape (e.g. a brand-new
+   * account with no persisted prefs yet, where WordPress inlines `""`).
+   */
+  function readPersistedPreferences(doc) {
+    if (!doc || !doc.querySelectorAll) return null;
+
+    const scripts = doc.querySelectorAll('script:not([src])');
+    for (let i = 0; i < scripts.length; i++) {
+      const text = scripts[i].textContent || '';
+      if (!text.includes('__unstableCreatePersistenceLayer')) continue;
+
+      const match = text.match(/var\s+serverData\s*=\s*(\{[\s\S]*?\});\s*\n?\s*var\s+userId/);
+      if (!match) continue;
+
+      try {
+        return JSON.parse(match[1]);
+      } catch (_) {
+        continue; // malformed/unexpected shape — try the next script, if any
+      }
+    }
+    return null;
+  }
+
+  /**
+   * True unless `serverData` already has the preference set to `true` under
+   * the shared "core" scope. Missing data (null/not-yet-persisted) is
+   * treated as "needs it" — safe because the actual write is a `wp.data`
+   * dispatch that only turns the preference on, never off; a false positive
+   * here at worst repeats a no-op set, not a wrong value.
+   */
+  function needsListViewDefault(serverData) {
+    if (!serverData) return true;
+    return (serverData[SCOPE] || {})[PREFERENCE_NAME] !== true;
+  }
+
+  globalThis.WPEditorPreferences = {
+    SCOPE,
+    PREFERENCE_NAME,
+    readPersistedPreferences,
+    needsListViewDefault,
+  };
+})();

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
@@ -35,7 +35,7 @@
     },
     {
       "matches": ["http://*/*", "https://*/*"],
-      "js": ["lib/detect.js", "lib/rest.js", "lib/host.js", "lib/block-inspector.js", "content.js"],
+      "js": ["lib/detect.js", "lib/rest.js", "lib/host.js", "lib/block-inspector.js", "lib/editor-preferences.js", "content.js"],
       "run_at": "document_idle",
       "all_frames": false
     }

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/options/options.html
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/options/options.html
@@ -24,6 +24,17 @@
 		</section>
 
 		<section class="wpd-options__section">
+			<h2 data-i18n="options_editor_section">Block Editor</h2>
+			<label class="wpd-option">
+				<input type="checkbox" id="listViewDefaultEnabled">
+				<span class="wpd-option__label">
+					<span class="wpd-option__title" data-i18n="options_list_view_default_label">Always open List View</span>
+					<span class="wpd-option__hint" data-i18n="options_list_view_default_hint">When enabled, sets your "List View" editor preference to open by default on every WordPress site you sign into — the same change as turning it on yourself in Editor Preferences. Off by default; only ever turns the preference on, never off.</span>
+				</span>
+			</label>
+		</section>
+
+		<section class="wpd-options__section">
 			<h2 data-i18n="options_experimental_section">Experimental</h2>
 			<label class="wpd-option">
 				<input type="checkbox" id="siteInfoEnabled">

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/options/options.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/options/options.js
@@ -17,6 +17,7 @@ const PREFS_KEY = 'wp_preferences_v1';
 const GLOBAL_NS = '_global';
 
 const adminBarToggle = document.getElementById('adminBarHiddenDefault');
+const listViewDefaultToggle = document.getElementById('listViewDefaultEnabled');
 const siteInfoToggle = document.getElementById('siteInfoEnabled');
 const resetButton = document.getElementById('resetData');
 const resetStatus = document.getElementById('resetStatus');
@@ -42,10 +43,15 @@ async function saveGlobalPref(key, value) {
 (async () => {
 	const globalPrefs = await loadGlobalPrefs();
 	adminBarToggle.checked = globalPrefs.adminBarHidden === true;
+	listViewDefaultToggle.checked = globalPrefs.listViewDefaultEnabled === true;
 	siteInfoToggle.checked = globalPrefs.siteInfoEnabled === true;
 
 	adminBarToggle.addEventListener('change', () => {
 		saveGlobalPref('adminBarHidden', adminBarToggle.checked);
+	});
+
+	listViewDefaultToggle.addEventListener('change', () => {
+		saveGlobalPref('listViewDefaultEnabled', listViewDefaultToggle.checked);
 	});
 
 	siteInfoToggle.addEventListener('change', () => {
@@ -57,6 +63,7 @@ async function saveGlobalPref(key, value) {
 		if (area !== 'local' || !changes[PREFS_KEY]) return;
 		const incoming = (changes[PREFS_KEY].newValue || {})[GLOBAL_NS] || {};
 		adminBarToggle.checked = incoming.adminBarHidden === true;
+		listViewDefaultToggle.checked = incoming.listViewDefaultEnabled === true;
 		siteInfoToggle.checked = incoming.siteInfoEnabled === true;
 	});
 
@@ -71,6 +78,7 @@ async function saveGlobalPref(key, value) {
 			// wp_devtools_open behind).
 			await chrome.storage.local.clear();
 			adminBarToggle.checked = false;
+			listViewDefaultToggle.checked = false;
 			siteInfoToggle.checked = false;
 			resetStatus.textContent = chrome.i18n.getMessage('options_cleared_success'); // "Cleared."
 			resetStatus.dataset.tone = 'ok';

--- a/scripts/package-chrome.sh
+++ b/scripts/package-chrome.sh
@@ -40,6 +40,7 @@ cp lib/detect.js           "$STAGE/lib/"
 cp lib/rest.js             "$STAGE/lib/"
 cp lib/host.js             "$STAGE/lib/"
 cp lib/block-inspector.js  "$STAGE/lib/"
+cp lib/editor-preferences.js "$STAGE/lib/"
 cp lib/my-sites.js         "$STAGE/lib/"
 
 cp popup/popup.html "$STAGE/popup/"

--- a/scripts/sync-safari.sh
+++ b/scripts/sync-safari.sh
@@ -36,6 +36,7 @@ cp "$ROOT/lib/detect.js"           "$DEST/lib/"
 cp "$ROOT/lib/rest.js"             "$DEST/lib/"
 cp "$ROOT/lib/host.js"             "$DEST/lib/"
 cp "$ROOT/lib/block-inspector.js"  "$DEST/lib/"
+cp "$ROOT/lib/editor-preferences.js" "$DEST/lib/"
 cp "$ROOT/lib/my-sites.js"         "$DEST/lib/"
 
 cp "$ROOT/popup/popup.html" "$DEST/popup/"

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -24,6 +24,7 @@ const restSrc   = fs.readFileSync(path.join(__dirname, '..', 'lib', 'rest.js'), 
 const hostSrc   = fs.readFileSync(path.join(__dirname, '..', 'lib', 'host.js'),   'utf8');
 const mySitesSrc = fs.readFileSync(path.join(__dirname, '..', 'lib', 'my-sites.js'), 'utf8');
 const blockInspectorSrc = fs.readFileSync(path.join(__dirname, '..', 'lib', 'block-inspector.js'), 'utf8');
+const editorPreferencesSrc = fs.readFileSync(path.join(__dirname, '..', 'lib', 'editor-preferences.js'), 'utf8');
 
 function loadModules(dom) {
   const ctx = dom.window;
@@ -37,6 +38,7 @@ function loadModules(dom) {
   // exposed for these tests). Only defines functions at load — the DOM/observer
   // work happens inside enable(), which the tests don't call.
   new Function('globalThis', 'document', 'window', blockInspectorSrc)(ctx, ctx.document, ctx);
+  new Function('globalThis', 'document', 'window', editorPreferencesSrc)(ctx, ctx.document, ctx);
   return ctx;
 }
 
@@ -1175,6 +1177,73 @@ async function main() {
 
     // Oversized input is bounded out rather than parsed.
     assert(parse('x'.repeat(2 * 1024 * 1024 + 1)).length === 0, 'oversized input returns no blocks');
+  }
+
+  // --- 31. Editor preferences: reading the inlined snapshot + gating -----
+  {
+    console.log('\n[31] WPEditorPreferences — DOM snapshot read + needsListViewDefault gating');
+
+    // Realistic shape of the inline script WordPress core emits next to the
+    // `wp-preferences` handle (see wp_default_packages_inline_scripts()).
+    const inlineScript = (serverDataJson) => `
+      ( function() {
+        var serverData = ${serverDataJson};
+        var userId = "5";
+        var persistenceLayer = wp.preferencesPersistence.__unstableCreatePersistenceLayer( serverData, userId );
+        var preferencesStore = wp.preferences.store;
+        wp.data.dispatch( preferencesStore ).setPersistenceLayer( persistenceLayer );
+      } ) ();
+    `;
+
+    // Both the post editor and the site editor read/write the SAME shared
+    // "core" scope for this preference (edit-post.js and edit-site.js both
+    // call getPreference("core", "showListViewByDefault")) — there is no
+    // separate per-surface scope.
+    const dom1 = new JSDOM(`<html><body><script>${inlineScript(
+      '{"core":{"showListViewByDefault":false,"distractionFree":true}}'
+    )}</script></body></html>`);
+    const ctx1 = loadModules(dom1);
+    const { readPersistedPreferences, needsListViewDefault, SCOPE } = ctx1.WPEditorPreferences;
+    assert(SCOPE === 'core', 'scope constant is the shared "core" preferences scope');
+    const data1 = readPersistedPreferences(ctx1.document);
+    assert(data1 && data1.core.showListViewByDefault === false,
+      'parses serverData out of the inline script');
+    assert(needsListViewDefault(data1) === true,
+      'needs it when the preference is false');
+
+    // Already on → nothing to do.
+    const dom2 = new JSDOM(`<html><body><script>${inlineScript(
+      '{"core":{"showListViewByDefault":true}}'
+    )}</script></body></html>`);
+    const ctx2 = loadModules(dom2);
+    const data2 = ctx2.WPEditorPreferences.readPersistedPreferences(ctx2.document);
+    assert(ctx2.WPEditorPreferences.needsListViewDefault(data2) === false,
+      'already true → does not need it');
+
+    // Brand-new account: WordPress inlines `""` (empty user meta), not an
+    // object — regex doesn't match "{...}", so read returns null.
+    const dom3 = new JSDOM(`<html><body><script>${inlineScript('""')}</script></body></html>`);
+    const ctx3 = loadModules(dom3);
+    assert(ctx3.WPEditorPreferences.readPersistedPreferences(ctx3.document) === null,
+      'non-object serverData (new account) reads as null');
+    assert(ctx3.WPEditorPreferences.needsListViewDefault(null) === true,
+      'null snapshot → treated as needing it');
+
+    // No matching inline script at all (e.g. not a block editor page).
+    const dom4 = new JSDOM(`<html><body><script>console.log('unrelated');</script></body></html>`);
+    const ctx4 = loadModules(dom4);
+    assert(ctx4.WPEditorPreferences.readPersistedPreferences(ctx4.document) === null,
+      'no wp-preferences inline script → null');
+
+    // "core" scope present (other prefs saved) but this key absent — still
+    // reads as needing it.
+    const dom5 = new JSDOM(`<html><body><script>${inlineScript(
+      '{"core":{"distractionFree":true}}'
+    )}</script></body></html>`);
+    const ctx5 = loadModules(dom5);
+    const data5 = ctx5.WPEditorPreferences.readPersistedPreferences(ctx5.document);
+    assert(ctx5.WPEditorPreferences.needsListViewDefault(data5) === true,
+      'scope present but preference key absent → still needs it');
   }
 
   console.log(`\n${failures === 0 ? 'All tests passed.' : failures + ' failure(s).'}`);


### PR DESCRIPTION
## Summary
Closes #32. Adds an opt-in, off-by-default option that turns on "Always open
List View" for the current user across every WordPress site's Block Editor
(post editor + Site Editor) — a one-time toggle instead of the per-site
manual step the issue describes.

## How it works
- WordPress persists this preference server-side under a single shared
  `"core"` preferences scope (`getPreference("core", "showListViewByDefault")`
  — same call in both edit-post.js and edit-site.js), not purely
  localStorage as the issue's acceptance criteria suggested. localStorage
  is still involved as a local write-through cache with timestamp-based
  conflict resolution, but the source of truth is server-side user meta,
  and both are read/written together through one preferences store.
- `lib/editor-preferences.js` reads WordPress's own already-inlined
  preferences snapshot from the DOM (the same data `wp.data` hydrates from)
  to check, with no REST call, whether the preference is already on.
- If it isn't, content.js asks background.js to dispatch
  `wp.data.dispatch('core/preferences').set('core', 'showListViewByDefault', true)`
  in the page's MAIN world — the same store action a user's own click on
  that Editor Preferences toggle triggers. WordPress's own existing
  debounced local-cache + REST persistence handles the actual save, so the
  extension never touches the REST API or the stored JSON directly — no
  risk of clobbering other saved preferences (dark mode, panel state, etc).

## Data & privacy / permissions
- No new `manifest.json` permissions — `storage` and `scripting` were
  already granted; the write happens through the page's own
  already-authenticated `wp.data`, not a new endpoint the extension calls.
- Off by default. Only ever turns the preference on, never off.
- New global option lives alongside the existing admin-bar/site-info
  defaults in `wp_preferences_v1._global` — no new storage keys.

## Open question for maintainers
The issue's phrasing implies "just make it always on." I made it an
explicit opt-in toggle instead, matching the Site Info panel / admin-bar
precedent in this repo, since it writes to the signed-in user's own
account preferences. Happy to flip it to on-by-default if you'd rather
match the issue literally.

## Test plan
- [x] `cd test && npm test` — new smoke coverage for
  `lib/editor-preferences.js` (DOM snapshot parsing, the "needs it" gate,
  new-account edge case, missing-preference-key edge case)
- [x] `npm run build` — clean
- [x] Manually verified end-to-end against a real logged-in WordPress
  editor session: baseline `showListViewByDefault: false` → enable the new
  option → reload the editor → `true`, confirmed persisted server-side via
  a fresh page load re-reading WordPress's own hydrated snapshot (not
  leftover client state) → reload again, stable, no repeat writes, no
  console errors