### PR TITLE
Strip activeTab from the Chrome package: redundant next to host permissions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,3 +39,9 @@ We aim to acknowledge reports within five business days. After triage we coordin
 ## Permissions reasoning
 
 The extension requests `storage`, `activeTab`, `scripting`, `cookies`, and `host_permissions` for `http://*/*` and `https://*/*`. The reasoning for each is documented in [`CONTRIBUTING.md`](CONTRIBUTING.md#conventions). New permission requests are discussed publicly before being added, and the v1.0 milestone freezes the surface.
+
+### Chrome package: `activeTab` removed
+
+The **shipped Chrome package** drops `activeTab`. With the broad `http`/`https` host permissions already present, `activeTab` grants nothing extra — Chrome's restricted "on click" site-access mode works by withholding and re-granting host permissions on invocation, not through `activeTab` — and the Chrome Web Store expects the narrowest permission set that supports shipped functionality. `scripts/package-chrome.sh` stages the manifest through `scripts/stage-chrome-manifest.js`, which filters `activeTab` out. This is the only point where the submitted Chrome manifest diverges from the repository manifest.
+
+The **repository manifest**, which the Safari build mirrors verbatim, keeps `activeTab` for now: an earlier permission-narrowing experiment broke Safari detection in ways we didn't foresee, so Safari-side removal is deferred to the Safari / App Store store-readiness pass, where it will be re-evaluated and tested before submission. Until then Safari intentionally ships the superset. See [issue #61](https://github.com/WordPress/browser-extension/issues/61).

--- a/scripts/package-chrome.sh
+++ b/scripts/package-chrome.sh
@@ -27,7 +27,11 @@ npm run build > /dev/null
 rm -rf "$STAGE"
 mkdir -p "$STAGE/lib" "$STAGE/popup" "$STAGE/options" "$STAGE/dist" "$STAGE/icons"
 
-cp manifest.json    "$STAGE/"
+# Chrome ships the narrowest permission set: the staged manifest drops
+# activeTab (redundant next to host_permissions). This is the ONLY point where
+# the shipped Chrome manifest diverges from the repo manifest — the repo/Safari
+# manifest keeps activeTab for now. See scripts/stage-chrome-manifest.js and #61.
+node "$ROOT/scripts/stage-chrome-manifest.js" manifest.json "$STAGE/manifest.json"
 cp background.js    "$STAGE/"
 cp content.js       "$STAGE/"
 

--- a/scripts/stage-chrome-manifest.js
+++ b/scripts/stage-chrome-manifest.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+/**
+ * Produces the Chrome-store manifest from the repository manifest.
+ *
+ * The Chrome package ships the narrowest permission set that supports its
+ * functionality: `activeTab` is dropped because it is redundant next to the
+ * broad http and https host_permissions the extension already declares.
+ * Chrome's restricted "on click" site-access mode is implemented by the
+ * browser withholding and re-granting those host permissions on invocation —
+ * it does not rely on `activeTab` — so removing it changes no runtime behavior
+ * while shrinking the surface the Chrome Web Store reviews and the listing has
+ * to justify. See issue #61 and SECURITY.md.
+ *
+ * This transform is the ONLY point where the shipped Chrome manifest diverges
+ * from the repository manifest. The repository manifest — which the Safari
+ * build mirrors verbatim — keeps `activeTab` for now; a prior
+ * permission-narrowing experiment broke Safari detection, so Safari-side
+ * removal is deferred to the Safari / App Store store-readiness pass.
+ *
+ * Usage:  node scripts/stage-chrome-manifest.js <src-manifest> <dest-manifest>
+ * Also exported (chromeManifest / CHROME_DROP_PERMISSIONS) for the test suite.
+ */
+const fs = require('fs');
+
+// Permissions removed from the repository manifest when packaging for Chrome.
+const CHROME_DROP_PERMISSIONS = ['activeTab'];
+
+// Return a copy of `manifest` with the Chrome-dropped permissions filtered out.
+// Key order and every field value are preserved; the only semantic change is the
+// removed permission(s). (The staged file re-serializes, so its JSON whitespace
+// is normalized — it is a generated release artifact, never committed, and the
+// Chrome Web Store consumes it as parsed JSON.)
+function chromeManifest(manifest) {
+  const out = { ...manifest };
+  if (Array.isArray(out.permissions)) {
+    out.permissions = out.permissions.filter((p) => !CHROME_DROP_PERMISSIONS.includes(p));
+  }
+  return out;
+}
+
+if (require.main === module) {
+  const [src, dest] = process.argv.slice(2);
+  if (!src || !dest) {
+    console.error('Usage: node scripts/stage-chrome-manifest.js <src-manifest> <dest-manifest>');
+    process.exit(1);
+  }
+  const manifest = JSON.parse(fs.readFileSync(src, 'utf8'));
+  const staged = chromeManifest(manifest);
+  fs.writeFileSync(dest, JSON.stringify(staged, null, 2) + '\n');
+  const dropped = (manifest.permissions || []).filter(
+    (p) => !(staged.permissions || []).includes(p)
+  );
+  console.log(`✓ staged Chrome manifest (dropped: ${dropped.join(', ') || 'none'})`);
+}
+
+module.exports = { chromeManifest, CHROME_DROP_PERMISSIONS };

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1177,6 +1177,36 @@ async function main() {
     assert(parse('x'.repeat(2 * 1024 * 1024 + 1)).length === 0, 'oversized input returns no blocks');
   }
 
+  // --- 31. Chrome manifest staging — activeTab dropped, rest intact ------
+  {
+    console.log('\n[31] stage-chrome-manifest — Chrome package drops only activeTab');
+    const { chromeManifest, CHROME_DROP_PERMISSIONS } =
+      require('../scripts/stage-chrome-manifest.js');
+    const repo = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'manifest.json'), 'utf8'));
+
+    // Invariant: the repo manifest (which the Safari build mirrors verbatim)
+    // keeps activeTab. Only the Chrome package strips it; Safari removal is a
+    // separate, later pass. If this fails, the divergence has leaked into the
+    // shared manifest.
+    assert(repo.permissions.includes('activeTab'),
+      'repo manifest keeps activeTab (Safari-mirror invariant)');
+    assert(CHROME_DROP_PERMISSIONS.includes('activeTab'), 'activeTab is on the Chrome drop list');
+
+    const chrome = chromeManifest(repo);
+    assert(!chrome.permissions.includes('activeTab'), 'staged Chrome manifest drops activeTab');
+    assert(['storage', 'scripting', 'cookies'].every((p) => chrome.permissions.includes(p)),
+      'staged Chrome manifest keeps storage/scripting/cookies');
+    assert(JSON.stringify(chrome.host_permissions) === JSON.stringify(repo.host_permissions),
+      'host_permissions unchanged in the Chrome manifest');
+
+    // Nothing but `permissions` may differ, and the input must not be mutated.
+    const changed = Object.keys(repo)
+      .filter((k) => k !== 'permissions')
+      .filter((k) => JSON.stringify(repo[k]) !== JSON.stringify(chrome[k]));
+    assert(changed.length === 0, `only permissions differ (changed: ${changed.join(', ') || 'none'})`);
+    assert(repo.permissions.includes('activeTab'), 'chromeManifest does not mutate its input');
+  }
+
   console.log(`\n${failures === 0 ? 'All tests passed.' : failures + ' failure(s).'}`);
   process.exit(failures === 0 ? 0 : 1);
 }


### PR DESCRIPTION
## Summary

Removes `activeTab` from the **shipped Chrome package** only. Ahead of the v1.0 permission freeze and the Chrome Web Store submission, this trims the packaged permission set to the minimum that supports shipped functionality.

With the extension's broad `http`/`https` `host_permissions` present, `activeTab` grants nothing extra — Chrome's restricted "on click" site-access mode works by withholding and re-granting host permissions on invocation, not through `activeTab`. The Web Store expects the narrowest permission set, and a redundant entry works against review and the listing's permission-justification fields.

The **repository manifest** (which the Safari build mirrors verbatim) keeps `activeTab` for now: a prior permission-narrowing experiment broke Safari detection, so Safari-side removal is deferred to the Safari / App Store store-readiness pass. Until then Safari intentionally ships the superset.

## Approach

- `scripts/stage-chrome-manifest.js` — a small Node transform that emits the Chrome-store manifest with `activeTab` filtered out of `permissions`.
- `scripts/package-chrome.sh` stages the manifest through it instead of copying it verbatim. **This is the single point where the shipped Chrome manifest diverges from the repository manifest.**
- The staged manifest still passes the `verify-package.js` integrity gate unchanged.

## Why this is safe (no `tabs` permission in the manifest)

Every `tab.url` / `chrome.scripting.executeScript` path rides on `host_permissions`, not on `activeTab`:

- Popup detection probe and clear-site-data `executeScript` target `{ tabId }` on an http/https page → host permissions.
- `background.js` reading `tab.url` (`tabs.query`, `onUpdated`) is host-permission-powered; `activeTab` (active-tab-only, gesture-only) never fed those paths.
- The popup opens via an action click, which in "on click" mode grants the withheld host permission for that tab.
- The `edit-this-page` command depends on the already-injected content script (`GET_LIVE_DETECTION`), which itself requires host access — so `activeTab`-only access was never sufficient for it.

## Tests

- New `test/smoke.js` scenario `[31]`: the staged Chrome manifest drops `activeTab` while keeping `storage`/`scripting`/`cookies` and `host_permissions`, no other field changes, and the input is not mutated. It also asserts the Safari-mirror invariant (repo `manifest.json` still declares `activeTab`), so a future edit that leaks the Chrome-only removal into the shared manifest fails the suite.
- Full suite green; `npm run package:chrome` builds cleanly and the resulting zip ships `["storage","scripting","cookies"]` + host permissions.

## Manual verification remaining (issue checklist)

These need a real browser and are not exercised here:

- [ ] Chrome: load the packaged (trimmed) build; confirm detection, popup probe, and clear-site-data work.
- [ ] Chrome: set site access to "when you click the extension" and confirm on-click behavior still works without `activeTab`.
- [ ] Safari (deferred): re-evaluate removing `activeTab` from the shared manifest before the App Store submission.

Refs #61
