### PR TITLE
v0.11.1: store-facing summary copy

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -8,8 +8,8 @@
     "description": "Short name shown where space is limited"
   },
   "ext_description": {
-    "message": "Detect WordPress sites, jump to the editor, identify the host, toggle the admin bar, and more.",
-    "description": "Extension description shown in the browser's extension store and management pages"
+    "message": "Quick access to your WordPress sites, content editing, and developer tools. Tuck away the admin bar.",
+    "description": "Extension description shown in the browser's extension store and management pages. The Chrome Web Store shows it as the listing summary and enforces a 132-character limit."
   },
   "ext_action_title": {
     "message": "WordPress Browser Extension",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_ext_name__",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "short_name": "__MSG_ext_short_name__",
   "description": "__MSG_ext_description__",
   "default_locale": "en",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wordpress-browser-extension",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wordpress-browser-extension",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@wordpress/icons": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordpress-browser-extension",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "Browser extension that detects WordPress sites and surfaces admin/developer shortcuts.",
   "license": "MIT",

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/_locales/en/messages.json
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/_locales/en/messages.json
@@ -8,8 +8,8 @@
     "description": "Short name shown where space is limited"
   },
   "ext_description": {
-    "message": "Detect WordPress sites, jump to the editor, identify the host, toggle the admin bar, and more.",
-    "description": "Extension description shown in the browser's extension store and management pages"
+    "message": "Quick access to your WordPress sites, content editing, and developer tools. Tuck away the admin bar.",
+    "description": "Extension description shown in the browser's extension store and management pages. The Chrome Web Store shows it as the listing summary and enforces a 132-character limit."
   },
   "ext_action_title": {
     "message": "WordPress Browser Extension",

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_ext_name__",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "short_name": "__MSG_ext_short_name__",
   "description": "__MSG_ext_description__",
   "default_locale": "en",

--- a/safari/WordPress Browser Extension/WordPress Browser Extension.xcodeproj/project.pbxproj
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 0.11.0;
+				MARKETING_VERSION = 0.11.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -495,7 +495,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 0.11.0;
+				MARKETING_VERSION = 0.11.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -533,7 +533,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.0;
+				MARKETING_VERSION = 0.11.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -574,7 +574,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.0;
+				MARKETING_VERSION = 0.11.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,


### PR DESCRIPTION
One-string release: the Chrome Web Store reads the listing summary from the package manifest's `description` (`__MSG_ext_description__`) and offers no dashboard override, so the summary copy written for the store listing moves into `_locales/en/messages.json`. Bumps to 0.11.1 so the store draft can take the corrected package (store versions must strictly increase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)