### PR TITLE
Mobile Preview: one window per site, navigated to the requested page

### DIFF
--- a/background.js
+++ b/background.js
@@ -239,10 +239,11 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 
   // Mobile Preview opens route through here (not the popup calling
-  // windows.create) so a repeat click on the same URL focuses the window
-  // already open instead of stacking a duplicate, and so the Safari size
-  // re-assert (issue #13) outlives the popup. Extension pages only — a content
-  // script must not be able to open arbitrary windows.
+  // windows.create) so a repeat click reuses the site's preview window —
+  // navigated to the requested page and focused — instead of stacking a
+  // duplicate, and so the Safari size re-assert (issue #13) outlives the
+  // popup. Extension pages only — a content script must not be able to open
+  // or steer windows.
   if (msg.type === 'OPEN_MOBILE_PREVIEW') {
     if (!isExtensionPageSender(sender)) return;
     openOrFocusPreview(msg.url, msg.enforceSize)
@@ -306,12 +307,16 @@ function isExtensionPageSender(sender) {
 
 // --- Mobile Preview windows ------------------------------------------------
 //
-// Reuse the preview window already open for a URL instead of opening a
-// duplicate on every click. We remember the id of each window we open, keyed by
-// its exact URL, and a repeat click focuses that window. Tracking our own ids
+// One preview window per site: the map keys on the URL's origin, so browsing
+// around a site reuses the window already open for it (navigated to the new
+// page and focused) while distinct sites keep distinct windows that can sit
+// side by side. Origin rather than registrable domain on purpose: WordPress
+// treats the scheme as part of the site URL, multisite subdomain installs are
+// separate sites, and domain grouping would need public-suffix logic for no
+// gain. It also matches how the detection cache is keyed. Tracking our own ids
 // (rather than scanning windows.getAll and matching tab.url) needs no host
 // access, so it's unaffected by Safari's user-gated host permissions, and it
-// only ever focuses a window we actually opened.
+// only ever touches windows we actually opened.
 //
 // The map lives in chrome.storage.session so it survives the service worker
 // being evicted between clicks — a plain variable would be gone by the next
@@ -323,7 +328,7 @@ const PREVIEW_W = 393;
 const PREVIEW_H = 852;
 const PREVIEW_WINDOWS_KEY = 'wp_preview_windows';
 const sessionStore = chrome.storage && chrome.storage.session ? chrome.storage.session : null;
-let previewWindowsFallback = {}; // url -> windowId, used only when storage.session is absent
+let previewWindowsFallback = {}; // origin -> windowId, used only when storage.session is absent
 
 async function getPreviewWindows() {
   if (!sessionStore) return { ...previewWindowsFallback };
@@ -342,34 +347,48 @@ async function setPreviewWindows(map) {
   } catch (_) { /* ignore — worst case is one duplicate window */ }
 }
 
-// Focus the preview already open for this exact URL, else open a new one. A
-// stored id whose window the user has closed makes windows.get throw; we drop
-// it and open fresh, so no close listener is needed to prune the map.
-// enforceSize is set by the popup on Safari only (see issue #13).
+// Reuse the preview already open for this URL's origin — navigate it to the
+// requested page and focus it — else open a new one. Navigating on every reuse
+// (rather than only when the URL differs) is deliberate: without the tabs
+// permission we cannot read what the window currently shows, and always
+// pointing it at the requested page keeps it honest even after the user
+// browses inside it. A stored id whose window the user has closed makes
+// windows.get throw; we drop it and open fresh, so no close listener is needed
+// to prune the map. enforceSize is set by the popup on Safari only (see #13).
 async function openOrFocusPreview(url, enforceSize) {
   if (typeof url !== 'string' || !url) return;
+  let origin;
+  try {
+    origin = new URL(url).origin;
+  } catch (_) {
+    return; // not a URL we can key — the popup never sends these
+  }
 
   const windows = await getPreviewWindows();
-  const existingId = windows[url];
+  const existingId = windows[origin];
   if (existingId != null) {
     try {
-      await chrome.windows.get(existingId); // throws if the user has closed it
+      // populate:true exposes the window's tab id (never gated — only url and
+      // title need the tabs permission), which tabs.update needs to navigate.
+      const win = await chrome.windows.get(existingId, { populate: true });
+      const tab = win.tabs && win.tabs[0];
+      if (tab && tab.id != null) await chrome.tabs.update(tab.id, { url });
       await chrome.windows.update(existingId, { focused: true });
       return;
     } catch (_) {
-      delete windows[url]; // stale id — fall through and open fresh
+      delete windows[origin]; // stale id — fall through and open fresh
     }
   }
 
   let win;
   try {
     win = await chrome.windows.create({ url, type: 'popup', width: PREVIEW_W, height: PREVIEW_H });
-  } catch (_) {
+  } catch (err) {
     await setPreviewWindows(windows); // persist the stale-id eviction above
-    return;
+    throw err; // surfaces as { ok: false } to the popup
   }
   if (win && win.id != null) {
-    windows[url] = win.id;
+    windows[origin] = win.id;
     if (enforceSize) enforcePreviewSize(win.id, PREVIEW_W, PREVIEW_H);
   }
   await setPreviewWindows(windows);

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
@@ -239,10 +239,11 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   }
 
   // Mobile Preview opens route through here (not the popup calling
-  // windows.create) so a repeat click on the same URL focuses the window
-  // already open instead of stacking a duplicate, and so the Safari size
-  // re-assert (issue #13) outlives the popup. Extension pages only — a content
-  // script must not be able to open arbitrary windows.
+  // windows.create) so a repeat click reuses the site's preview window —
+  // navigated to the requested page and focused — instead of stacking a
+  // duplicate, and so the Safari size re-assert (issue #13) outlives the
+  // popup. Extension pages only — a content script must not be able to open
+  // or steer windows.
   if (msg.type === 'OPEN_MOBILE_PREVIEW') {
     if (!isExtensionPageSender(sender)) return;
     openOrFocusPreview(msg.url, msg.enforceSize)
@@ -306,12 +307,16 @@ function isExtensionPageSender(sender) {
 
 // --- Mobile Preview windows ------------------------------------------------
 //
-// Reuse the preview window already open for a URL instead of opening a
-// duplicate on every click. We remember the id of each window we open, keyed by
-// its exact URL, and a repeat click focuses that window. Tracking our own ids
+// One preview window per site: the map keys on the URL's origin, so browsing
+// around a site reuses the window already open for it (navigated to the new
+// page and focused) while distinct sites keep distinct windows that can sit
+// side by side. Origin rather than registrable domain on purpose: WordPress
+// treats the scheme as part of the site URL, multisite subdomain installs are
+// separate sites, and domain grouping would need public-suffix logic for no
+// gain. It also matches how the detection cache is keyed. Tracking our own ids
 // (rather than scanning windows.getAll and matching tab.url) needs no host
 // access, so it's unaffected by Safari's user-gated host permissions, and it
-// only ever focuses a window we actually opened.
+// only ever touches windows we actually opened.
 //
 // The map lives in chrome.storage.session so it survives the service worker
 // being evicted between clicks — a plain variable would be gone by the next
@@ -323,7 +328,7 @@ const PREVIEW_W = 393;
 const PREVIEW_H = 852;
 const PREVIEW_WINDOWS_KEY = 'wp_preview_windows';
 const sessionStore = chrome.storage && chrome.storage.session ? chrome.storage.session : null;
-let previewWindowsFallback = {}; // url -> windowId, used only when storage.session is absent
+let previewWindowsFallback = {}; // origin -> windowId, used only when storage.session is absent
 
 async function getPreviewWindows() {
   if (!sessionStore) return { ...previewWindowsFallback };
@@ -342,34 +347,48 @@ async function setPreviewWindows(map) {
   } catch (_) { /* ignore — worst case is one duplicate window */ }
 }
 
-// Focus the preview already open for this exact URL, else open a new one. A
-// stored id whose window the user has closed makes windows.get throw; we drop
-// it and open fresh, so no close listener is needed to prune the map.
-// enforceSize is set by the popup on Safari only (see issue #13).
+// Reuse the preview already open for this URL's origin — navigate it to the
+// requested page and focus it — else open a new one. Navigating on every reuse
+// (rather than only when the URL differs) is deliberate: without the tabs
+// permission we cannot read what the window currently shows, and always
+// pointing it at the requested page keeps it honest even after the user
+// browses inside it. A stored id whose window the user has closed makes
+// windows.get throw; we drop it and open fresh, so no close listener is needed
+// to prune the map. enforceSize is set by the popup on Safari only (see #13).
 async function openOrFocusPreview(url, enforceSize) {
   if (typeof url !== 'string' || !url) return;
+  let origin;
+  try {
+    origin = new URL(url).origin;
+  } catch (_) {
+    return; // not a URL we can key — the popup never sends these
+  }
 
   const windows = await getPreviewWindows();
-  const existingId = windows[url];
+  const existingId = windows[origin];
   if (existingId != null) {
     try {
-      await chrome.windows.get(existingId); // throws if the user has closed it
+      // populate:true exposes the window's tab id (never gated — only url and
+      // title need the tabs permission), which tabs.update needs to navigate.
+      const win = await chrome.windows.get(existingId, { populate: true });
+      const tab = win.tabs && win.tabs[0];
+      if (tab && tab.id != null) await chrome.tabs.update(tab.id, { url });
       await chrome.windows.update(existingId, { focused: true });
       return;
     } catch (_) {
-      delete windows[url]; // stale id — fall through and open fresh
+      delete windows[origin]; // stale id — fall through and open fresh
     }
   }
 
   let win;
   try {
     win = await chrome.windows.create({ url, type: 'popup', width: PREVIEW_W, height: PREVIEW_H });
-  } catch (_) {
+  } catch (err) {
     await setPreviewWindows(windows); // persist the stale-id eviction above
-    return;
+    throw err; // surfaces as { ok: false } to the popup
   }
   if (win && win.id != null) {
-    windows[url] = win.id;
+    windows[origin] = win.id;
     if (enforceSize) enforcePreviewSize(win.id, PREVIEW_W, PREVIEW_H);
   }
   await setPreviewWindows(windows);

--- a/src/popup/lib/actions.js
+++ b/src/popup/lib/actions.js
@@ -115,9 +115,10 @@ export async function runAction(action, { origin, baseUrl, url, editUrl, viewUrl
 	window.close();
 }
 
-// The background owns the preview window: it reuses one already open for this
-// URL instead of stacking a duplicate (the popup can't — it closes the moment
-// it dispatches), and it re-asserts the size Safari otherwise ignores (#13).
+// The background owns the preview window: one per site, so it reuses the
+// window already open for this URL's origin — navigating it to this page —
+// instead of stacking a duplicate (the popup can't — it closes the moment it
+// dispatches), and it re-asserts the size Safari otherwise ignores (#13).
 // navigator.vendor is reliable here (Safari-only), so we detect and pass it on.
 async function openMobilePreview(url) {
 	try {

--- a/test/background-storage.js
+++ b/test/background-storage.js
@@ -80,10 +80,12 @@ function loadBackground(storage) {
   const noopEvent = { addListener: () => {} };
 
   // Stateful windows stub: models open/closed windows so the Mobile Preview
-  // reuse path (create once, focus on repeat, reopen after close) can be
-  // observed. get() throws for a window the test has closed, exactly like the
-  // real API when openOrFocusPreview probes a stale id.
-  const winState = { nextId: 1000, open: new Set(), created: [], focused: [] };
+  // reuse path (create once, navigate + focus on repeat, reopen after close)
+  // can be observed. get() throws for a window the test has closed, exactly
+  // like the real API when openOrFocusPreview probes a stale id. Each window
+  // carries one tab (id + 5000) so the populate/tabs.update navigation path
+  // runs against its real shape.
+  const winState = { nextId: 1000, open: new Set(), created: [], focused: [], navigated: [] };
   const chromeStub = {
     runtime: {
       getURL: (p) => EXT_URL + p,
@@ -97,7 +99,12 @@ function loadBackground(storage) {
       onUpdated: noopEvent,
       query: async () => [],
       sendMessage: async () => ({}),
-      update: async () => {},
+      update: async (tabId, opts) => {
+        if (typeof tabId === 'number' && opts && opts.url) {
+          winState.navigated.push({ tabId, url: opts.url });
+        }
+        return { id: tabId };
+      },
     },
     action: {
       setIcon: (opts, cb) => { iconCalls.push(opts); cb && cb(); },
@@ -112,9 +119,11 @@ function loadBackground(storage) {
         winState.created.push({ id, url });
         return { id };
       },
-      get: async (id) => {
+      get: async (id, opts) => {
         if (!winState.open.has(id)) throw new Error('no such window');
-        return { id, state: 'normal', width: 393 };
+        const win = { id, state: 'normal', width: 393 };
+        if (opts && opts.populate) win.tabs = [{ id: id + 5000, windowId: id }];
+        return win;
       },
       update: async (id, opts) => {
         if (opts && opts.focused) winState.focused.push(id);
@@ -270,36 +279,57 @@ async function main() {
     assert(iconCalls.length === 1, 'popup sender and unknown origin ignored');
   }
 
-  // --- 40. Mobile Preview reuses the window already open for the same URL --
+  // --- 40. Mobile Preview keeps one window per site (origin) ---------------
   {
-    console.log('\n[40] Mobile Preview: same URL focuses the open window instead of duplicating');
+    console.log('\n[40] Mobile Preview: one window per site — reuse navigates, sites stay separate');
     const storage = makeStorage();
     const { send, winState, closeWindow } = loadBackground(storage);
-    const url = 'https://make.wordpress.org/core/2026/05/22/post/';
+    const pageA = 'https://make.wordpress.org/core/2026/05/22/post/';
+    const pageB = 'https://make.wordpress.org/core/2026/06/01/another-post/';
 
-    await send({ type: 'OPEN_MOBILE_PREVIEW', url, enforceSize: false }, POPUP_SENDER);
+    await send({ type: 'OPEN_MOBILE_PREVIEW', url: pageA, enforceSize: false }, POPUP_SENDER);
     assert(winState.created.length === 1, 'first click opens one preview window');
+    const firstWin = winState.created[0].id;
 
-    await send({ type: 'OPEN_MOBILE_PREVIEW', url, enforceSize: false }, POPUP_SENDER);
-    assert(winState.created.length === 1, 'second click on the same URL opens no new window');
-    assert(winState.focused.length === 1 && winState.focused[0] === winState.created[0].id,
-      'second click focuses the window already open');
+    // A different page on the same site reuses the window: navigate + focus.
+    await send({ type: 'OPEN_MOBILE_PREVIEW', url: pageB, enforceSize: false }, POPUP_SENDER);
+    assert(winState.created.length === 1, 'another page on the same site opens no new window');
+    assert(winState.navigated.length === 1
+      && winState.navigated[0].tabId === firstWin + 5000
+      && winState.navigated[0].url === pageB,
+      'the existing window is navigated to the newly requested page');
+    assert(winState.focused.length === 1 && winState.focused[0] === firstWin,
+      'and brought to front');
 
-    // A different URL still gets its own window.
-    const other = 'https://make.wordpress.org/core/2026/05/22/other/';
-    await send({ type: 'OPEN_MOBILE_PREVIEW', url: other, enforceSize: false }, POPUP_SENDER);
-    assert(winState.created.length === 2, 'a different URL opens a separate window');
+    // A repeat click for the page already showing re-navigates (we cannot read
+    // the tab's URL without the tabs permission, and re-pointing is harmless).
+    await send({ type: 'OPEN_MOBILE_PREVIEW', url: pageB, enforceSize: false }, POPUP_SENDER);
+    assert(winState.created.length === 1 && winState.navigated.length === 2,
+      'a repeat click for the same page still reuses and re-navigates');
 
-    // Once the user closes the first preview, its stored id goes stale; the
-    // same URL must open a fresh window rather than focus a window that's gone.
-    closeWindow(winState.created[0].id);
-    await send({ type: 'OPEN_MOBILE_PREVIEW', url, enforceSize: false }, POPUP_SENDER);
-    assert(winState.created.length === 3, 'closed preview reopens instead of focusing a gone window');
+    // A different site gets its own window, side by side with the first.
+    const otherSite = 'https://developer.wordpress.org/reference/';
+    await send({ type: 'OPEN_MOBILE_PREVIEW', url: otherSite, enforceSize: false }, POPUP_SENDER);
+    assert(winState.created.length === 2, 'a different site opens a separate window');
 
-    // A content-script sender must not be able to pop open windows.
-    const before = winState.created.length;
+    // Scheme is part of the site identity (WordPress treats it that way), so
+    // http and https of the same host do not share a window.
+    await send({ type: 'OPEN_MOBILE_PREVIEW', url: 'http://make.wordpress.org/core/', enforceSize: false }, POPUP_SENDER);
+    assert(winState.created.length === 3, 'http and https of the same host are distinct sites');
+
+    // Once the user closes a site's preview, its stored id goes stale; the
+    // same site must open a fresh window rather than focus a window that's gone.
+    closeWindow(firstWin);
+    const navsBefore = winState.navigated.length;
+    await send({ type: 'OPEN_MOBILE_PREVIEW', url: pageA, enforceSize: false }, POPUP_SENDER);
+    assert(winState.created.length === 4, 'closed preview reopens instead of focusing a gone window');
+    assert(winState.navigated.length === navsBefore, 'and nothing tries to navigate the gone window');
+
+    // A content-script sender must not be able to open or steer windows.
+    const before = { created: winState.created.length, navigated: winState.navigated.length };
     await send({ type: 'OPEN_MOBILE_PREVIEW', url: 'https://evil.example/x', enforceSize: false }, CONTENT_SENDER);
-    assert(winState.created.length === before, 'content-script sender is ignored');
+    assert(winState.created.length === before.created && winState.navigated.length === before.navigated,
+      'content-script sender is ignored');
   }
 
   console.log(`\n${failures === 0 ? 'Background storage tests passed.' : failures + ' failure(s).'}`);


### PR DESCRIPTION
Follows up on #66 / #67.

## Problem

The #67 fix keyed preview windows on the exact URL, so browsing to a different page on the same site and clicking Mobile Preview still stacked a new window. For one site being browsed page to page, that recreates the clutter #66 set out to remove, one level up.

## Change

One preview window per site. The window map now keys on the URL's **origin**; a click for any page on that site reuses the existing window, navigating it to the requested page and focusing it. Distinct sites still get distinct windows, so two sites can be compared side by side in mobile size.

Origin rather than registrable domain, deliberately: WordPress treats the scheme as part of the site URL, multisite subdomain installs are separate sites, and domain grouping would require public-suffix logic. This also matches how the extension keys its detection cache.

Navigating on every reuse (not only when the URL differs) is deliberate: without the `tabs` permission the extension cannot read what the window currently shows, and always pointing the window at the requested page keeps it honest even after manual navigation inside it. This removes the known edge in #67 where a repeat click could focus a window showing an unrelated page.

## Notes for reviewers

- **No new permissions.** The tab id needed for `tabs.update` comes from `windows.get(id, { populate: true })`; tab ids are not gated behind the `tabs` permission (only `url`/`title` are). Least-privilege intact.
- **No new outbound calls.** Privacy invariant intact.
- A failed `windows.create` now propagates so the popup receives `{ ok: false }` instead of a false success.
- `dist/popup.js` is intentionally untouched: the popup source change is comment-only and the minified bundle is byte-identical. Safari mirror regenerated via `npm run build:safari`.

## Testing

- `npm run lint` clean.
- Full suite passes. `test/background-storage.js` [40] rewritten for per-site semantics: same-site page reuses + navigates + focuses, repeat click re-navigates, different site opens its own window, http/https of one host stay distinct, a closed preview reopens fresh, and content-script senders are rejected for both opening and steering windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)