### PR TITLE
v0.11.2: version bump

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_ext_name__",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "short_name": "__MSG_ext_short_name__",
   "description": "__MSG_ext_description__",
   "default_locale": "en",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wordpress-browser-extension",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wordpress-browser-extension",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "dependencies": {
         "@wordpress/icons": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordpress-browser-extension",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "description": "Browser extension that detects WordPress sites and surfaces admin/developer shortcuts.",
   "license": "MIT",

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_ext_name__",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "short_name": "__MSG_ext_short_name__",
   "description": "__MSG_ext_description__",
   "default_locale": "en",

--- a/safari/WordPress Browser Extension/WordPress Browser Extension.xcodeproj/project.pbxproj
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 0.11.1;
+				MARKETING_VERSION = 0.11.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -495,7 +495,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 0.11.1;
+				MARKETING_VERSION = 0.11.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -533,7 +533,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
+				MARKETING_VERSION = 0.11.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -574,7 +574,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.1;
+				MARKETING_VERSION = 0.11.2;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,


### PR DESCRIPTION
Release metadata bump for 0.11.2.

## In this release

- Mobile Preview keeps one window per site: a repeat click reuses the open preview, navigating it to the requested page and focusing it; distinct sites keep distinct windows (#66, #67, #69).
- Dev-dependency security updates: ws 7.5.11 (#64), websocket-driver 0.7.5 (#68). Lockfile only, no shipped-code impact.

## Bump checklist

- manifest.json version
- package.json version
- package-lock.json (npm install --package-lock-only)
- MARKETING_VERSION in the four Safari build configs
- Safari Resources mirror re-synced (manifest picked up the new version)

Full test suite passes locally; CI runs the clean-rebuild dist/mirror drift check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)