### PR TITLE
v1.0.0: version bump

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_ext_name__",
-  "version": "0.11.2",
+  "version": "1.0.0",
   "short_name": "__MSG_ext_short_name__",
   "description": "__MSG_ext_description__",
   "default_locale": "en",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wordpress-browser-extension",
-  "version": "0.11.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wordpress-browser-extension",
-      "version": "0.11.2",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@wordpress/icons": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordpress-browser-extension",
-  "version": "0.11.2",
+  "version": "1.0.0",
   "private": true,
   "description": "Browser extension that detects WordPress sites and surfaces admin/developer shortcuts.",
   "license": "MIT",

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_ext_name__",
-  "version": "0.11.2",
+  "version": "1.0.0",
   "short_name": "__MSG_ext_short_name__",
   "description": "__MSG_ext_description__",
   "default_locale": "en",

--- a/safari/WordPress Browser Extension/WordPress Browser Extension.xcodeproj/project.pbxproj
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 0.11.2;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -495,7 +495,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 0.11.2;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -533,7 +533,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.2;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -574,7 +574,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.11.2;
+				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,


### PR DESCRIPTION
Version bump to 1.0.0, to be released first as the 1.0 release candidate (tagged v1.0.0-rc1, GitHub pre-release).

Functionally identical to v0.11.2. The only change since is internal Apple App Store preparation: Safari bundle identifiers moved to org.wordpress.browserextension under the WordPress Foundation developer account (#72).

Bump checklist: manifest.json, package.json, package-lock.json (npm install --package-lock-only), MARKETING_VERSION in four build configs, Safari Resources mirror re-synced. Full test suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)