### PR TITLE
Safari: declare export compliance in the container app Info.plist

### DIFF
--- a/safari/WordPress Browser Extension/WordPress Browser Extension/Info.plist
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<!-- The extension uses only HTTPS through the system's own networking, which
+	     qualifies for the standard export-compliance exemption. Declaring it here
+	     means App Store Connect stops holding each uploaded build in "Missing
+	     Compliance" pending a manual answer. -->
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>SFSafariWebExtensionConverterVersion</key>
 	<string>26.5</string>
 </dict>


### PR DESCRIPTION
Adds `ITSAppUsesNonExemptEncryption = false` to the Safari container app's `Info.plist`.

## Why

App Store Connect requires an export-compliance answer for every uploaded build. Without the declaration in the app itself, each upload lands in "Missing Compliance" and cannot be submitted until the question is answered by hand in the dashboard, every time.

`false` is the correct answer here: the extension uses only HTTPS through the system's own networking, with no proprietary or additional cryptography, which is the standard exemption.

## Impact

No runtime effect. The key is submission metadata; behavior, permissions, and the popup bundle are untouched. Verified by building Release and reading the key back out of the built app, alongside the existing identity checks:

- `ITSAppUsesNonExemptEncryption` = false
- `CFBundleShortVersionString` = 1.0.0
- `CFBundleIdentifier` = org.wordpress.browserextension
- `codesign --verify --deep --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)