### PR TITLE
Safari: declare LSApplicationCategoryType for App Store submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ safari/**/build/
 # Xcode build output (DerivedData/intermediates) when the Safari project is
 # built with its output directory set here — generated, never committed
 safari-build/
+# App Store archive and exported installer package — regenerated per
+# submission from the tagged source, never committed
+build/
 # local migration scratch — referenced during the transfer to
 # WordPress/browser-extension; not shipped to either repo
 .transfer/

--- a/safari/WordPress Browser Extension/WordPress Browser Extension/Info.plist
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension/Info.plist
@@ -8,6 +8,11 @@
 	     Compliance" pending a manual answer. -->
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<!-- Required for Mac App Store submission: the store rejects an archive
+	     whose Info.plist has no category UTI (error 90242). Keep this in sync
+	     with the primary category on the App Store Connect listing. -->
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
 	<key>SFSafariWebExtensionConverterVersion</key>
 	<string>26.5</string>
 </dict>


### PR DESCRIPTION
Fixes an App Store upload rejection found while submitting 1.0.0.

## The failure

Uploading the archive returned error 90242:

> The product archive is invalid. The Info.plist must contain a LSApplicationCategoryType key, whose value is the UTI for a valid category.

The category set on the App Store Connect listing does not satisfy this — Apple requires the category UTI inside the app bundle itself.

## Change

- `LSApplicationCategoryType` = `public.app-category.developer-tools` in the container app's `Info.plist`, matching the listing's primary category. A comment notes the two must stay in sync.
- `build/` added to `.gitignore`. That is where the App Store archive and exported `.pkg` land; `safari-build/` was already ignored, so this closes the same gap for the archive path and keeps a stray `git add -A` from committing a large binary.

No runtime effect; both are submission metadata and repo hygiene.

## Verification

Release build succeeds, and the built bundle now reports:

- `LSApplicationCategoryType` = public.app-category.developer-tools
- `ITSAppUsesNonExemptEncryption` = false (from #74)
- `CFBundleIconFile` = AppIcon, with `AppIcon.icns` present in Resources

The app icon set was checked at the same time and is complete (16pt through 512pt @1x/@2x), so it is not a second submission blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)