### PR TITLE
v1.0.1: version bump

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_ext_name__",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "short_name": "__MSG_ext_short_name__",
   "description": "__MSG_ext_description__",
   "default_locale": "en",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wordpress-browser-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wordpress-browser-extension",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@wordpress/icons": "^12.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordpress-browser-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Browser extension that detects WordPress sites and surfaces admin/developer shortcuts.",
   "license": "MIT",

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_ext_name__",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "short_name": "__MSG_ext_short_name__",
   "description": "__MSG_ext_description__",
   "default_locale": "en",

--- a/safari/WordPress Browser Extension/WordPress Browser Extension.xcodeproj/project.pbxproj
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -495,7 +495,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -533,7 +533,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,
@@ -574,7 +574,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.0.1;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SafariServices,


### PR DESCRIPTION
Version bump for the coordinated store launch. 1.0.1 supersedes 1.0.0 as the launch version: the approved Apple 1.0.0 build 1 predates the #76 QA pass and the #81 popup hardening, so it releases quietly as a safeguard while 1.0.1 (this content) ships everywhere as the announced version.

Checklist: manifest.json, package.json, package-lock.json (npm install --package-lock-only), MARKETING_VERSION in four build configs, Safari Resources mirror re-synced. CURRENT_PROJECT_VERSION stays 2 (#80; build 2 was never uploaded). Full test suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)