### PR TITLE
i18n: add Bulgarian (bg) message catalog

### DIFF
--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -1,0 +1,431 @@
+{
+  "ext_name": {
+    "message": "WordPress Browser Extension",
+    "description": "Extension name shown in browser UI"
+  },
+  "ext_short_name": {
+    "message": "WordPress",
+    "description": "Short name shown where space is limited"
+  },
+  "ext_description": {
+    "message": "Бърз достъп до вашите WordPress сайтове, редактиране на съдържание и инструменти за разработчици. Скрийте админ лентата.",
+    "description": "Extension description shown in the browser's extension store and management pages. The Chrome Web Store shows it as the listing summary and enforces a 132-character limit."
+  },
+  "ext_action_title": {
+    "message": "WordPress Browser Extension",
+    "description": "Tooltip for the toolbar icon button"
+  },
+  "cmd_edit_this_page": {
+    "message": "Редактиране на тази страница в WordPress",
+    "description": "Description for the keyboard shortcut command"
+  },
+
+  "options_page_title": {
+    "message": "WordPress Browser Extension — Настройки",
+    "description": "HTML page title for the options page"
+  },
+  "options_heading": {
+    "message": "WordPress Browser Extension",
+    "description": "H1 heading on the options page"
+  },
+  "options_subtitle": {
+    "message": "Настройки по подразбиране за целия браузър. Изборът за отделните сайтове остава в изскачащия прозорец на лентата с инструменти.",
+    "description": "Subtitle under the options page heading"
+  },
+  "options_admin_bar_section": {
+    "message": "Админ лента",
+    "description": "Section heading for admin bar settings"
+  },
+  "options_hide_admin_bar_label": {
+    "message": "Скриване на админ лентата по подразбиране",
+    "description": "Toggle label for the hide-admin-bar option"
+  },
+  "options_hide_admin_bar_hint": {
+    "message": "Когато е включено, админ лентата е скрита в новите WordPress сайтове. Настройките за отделните сайтове в изскачащия прозорец продължават да имат предимство.",
+    "description": "Hint text describing the hide-admin-bar toggle behavior"
+  },
+  "options_experimental_section": {
+    "message": "Експериментални",
+    "description": "Section heading for experimental features"
+  },
+  "options_site_info_label": {
+    "message": "Показване на панела с информация за сайта",
+    "description": "Toggle label for the site information panel option"
+  },
+  "options_site_info_hint": {
+    "message": "Добавя панел в изскачащия прозорец с активната тема, инсталираните плъгини, името на сайта и REST именните пространства. Разпознаването е евристично — извеждането по пътищата на файловете може да даде дублирания и фалшиви резултати (например mu-plugins и drop-ins). Изключено по подразбиране.",
+    "description": "Hint text describing the site information panel feature"
+  },
+  "options_data_section": {
+    "message": "Данни",
+    "description": "Section heading for data management settings"
+  },
+  "options_reset_label": {
+    "message": "Нулиране на данните на разширението",
+    "description": "Label for the reset/clear data option"
+  },
+  "options_reset_hint": {
+    "message": "Изчиства всички запазени настройки за отделните сайтове, глобалните настройки на тази страница и кешираните резултати „това WordPress сайт ли е“. Полезно при тестване или за започване начисто.",
+    "description": "Hint text describing what the reset action clears"
+  },
+  "options_clear_button": {
+    "message": "Изчистване на всички данни",
+    "description": "Button label to trigger clearing all extension data"
+  },
+  "options_clear_confirm": {
+    "message": "Да се изчистят ли всички данни на разширението?\n\nТова премахва всички запазени настройки за отделните сайтове, глобалните настройки на тази страница, кешираните резултати от разпознаването на WordPress и запазения списък „Моите сайтове“. Действието е необратимо.",
+    "description": "Confirmation dialog text shown before clearing all data"
+  },
+  "options_cleared_success": {
+    "message": "Изчистено.",
+    "description": "Status message shown after successfully clearing extension data"
+  },
+  "options_cleared_error": {
+    "message": "Данните не бяха изчистени. Опитайте отново.",
+    "description": "Status message shown when clearing extension data fails"
+  },
+
+  "toolbar_title_detected": {
+    "message": "Разпознат WordPress",
+    "description": "Toolbar icon tooltip when a WordPress site is detected but the user is not logged in"
+  },
+  "toolbar_title_detected_logged_in": {
+    "message": "Разпознат WordPress — влезли сте",
+    "description": "Toolbar icon tooltip when a WordPress site is detected and the user is logged in"
+  },
+  "toolbar_title_default": {
+    "message": "WordPress Browser Extension",
+    "description": "Default toolbar icon tooltip when no WordPress site is detected"
+  },
+  "admin_bar_hidden_notice": {
+    "message": "[WordPress Browser Extension] Админ лентата е скрита на този сайт. Превключете „Показване на админ лентата“ в изскачащия прозорец на разширението или на страницата с настройки.",
+    "description": "Console info message shown when the admin bar is hidden on a site"
+  },
+
+  "error_view_title": {
+    "message": "Нещо се обърка",
+    "description": "Title shown in the popup error state"
+  },
+  "error_view_description": {
+    "message": "Проверете логовете на service worker-а.",
+    "description": "Description shown in the popup error state"
+  },
+  "not_supported_title": {
+    "message": "Тук няма какво да се провери",
+    "description": "Title shown when the current tab cannot be inspected (e.g. new tab, browser pages)"
+  },
+  "not_supported_description": {
+    "message": "Отворете уебсайт, за да започнете.",
+    "description": "Description shown when the current tab cannot be inspected"
+  },
+  "not_wordpress_title": {
+    "message": "Не е WordPress сайт",
+    "description": "Title shown when the current site is not detected as WordPress"
+  },
+  "not_wordpress_description": {
+    "message": "Не са открити признаци.",
+    "description": "Description shown when the current site is not detected as WordPress"
+  },
+
+  "verb_view": {
+    "message": "Преглед на",
+    "description": "Verb prefix for viewing a published post/page from the WP admin edit screen"
+  },
+  "verb_preview": {
+    "message": "Визуализация на",
+    "description": "Verb prefix for previewing a draft post/page from the WP admin edit screen"
+  },
+  "visit_site": {
+    "message": "Към сайта",
+    "description": "Button label to visit the WordPress site's frontend"
+  },
+  "wordpress_admin": {
+    "message": "WordPress администрация",
+    "description": "Button label to open the WordPress admin dashboard"
+  },
+  "log_in": {
+    "message": "Вход",
+    "description": "Button label to log into a WordPress site"
+  },
+  "log_in_return": {
+    "message": "Вход и връщане към страницата",
+    "description": "Button label to log in and return to the current page"
+  },
+  "show_admin_bar": {
+    "message": "Показване на админ лентата",
+    "description": "Toggle label to show/hide the WordPress admin bar"
+  },
+  "admin_bar_disabled_info": {
+    "message": "Изглежда админ лентата е изключена от вашия профил или от темата, което ограничава това разширение.",
+    "description": "Info text shown when the admin bar cannot be toggled due to profile or theme settings"
+  },
+  "check_profile_link": {
+    "message": "Към профила →",
+    "description": "Link text directing users to their WordPress profile settings"
+  },
+
+  "copy_url_label": {
+    "message": "Копиране на URL",
+    "description": "Aria-label and tooltip for the copy URL button"
+  },
+  "copied_label": {
+    "message": "Копирано",
+    "description": "Aria-label and tooltip for the copy URL button after the URL has been copied"
+  },
+  "open_new_tab_label": {
+    "message": "Отваряне в нов раздел",
+    "description": "Aria-label and tooltip for the open-in-new-tab button"
+  },
+
+  "account_menu_label": {
+    "message": "Меню на профила",
+    "description": "Aria-label for the user account menu button when no display name is available"
+  },
+  "account_menu_for_user": {
+    "message": "Меню на профила за $NAME$",
+    "description": "Aria-label for the user account menu button when a display name is available",
+    "placeholders": {
+      "name": { "content": "$1" }
+    }
+  },
+  "profile_menu_item": {
+    "message": "Профил",
+    "description": "Menu item linking to the user's WordPress profile"
+  },
+  "gravatar_menu_item": {
+    "message": "Gravatar",
+    "description": "Menu item linking to the user's Gravatar profile"
+  },
+  "log_out_button": {
+    "message": "Изход",
+    "description": "Button label to log out of the WordPress site"
+  },
+  "confirm_click_button": {
+    "message": "Натиснете отново за потвърждение",
+    "description": "Button label shown after first click on a destructive action, prompting a second confirmation click"
+  },
+  "super_admin_role": {
+    "message": "Супер администратор",
+    "description": "Role badge label for WordPress multisite super administrators"
+  },
+
+  "new_content_label": {
+    "message": "Създаване",
+    "description": "Section label for the 'New content' action group in the popup"
+  },
+
+  "dev_tools_label": {
+    "message": "Инструменти за разработчици",
+    "description": "Section label for the developer tools group in the popup"
+  },
+  "highlight_blocks_toggle": {
+    "message": "Открояване на блоковете",
+    "description": "Toggle label for the block highlighter developer tool"
+  },
+  "mobile_preview_action": {
+    "message": "Мобилен изглед",
+    "description": "Action label to open the site in mobile preview mode"
+  },
+  "bypass_page_cache_action": {
+    "message": "Заобикаляне на кеша",
+    "description": "Action label to reload the page bypassing the server-side page cache"
+  },
+  "query_monitor_toggle": {
+    "message": "Query Monitor",
+    "description": "Toggle label for the Query Monitor plugin panel"
+  },
+  "clear_site_data_action": {
+    "message": "Изчистване на данните (запазва входа)",
+    "description": "Action label to clear browser site data while preserving the login session"
+  },
+
+  "confirm_label": {
+    "message": "Потвърждаване",
+    "description": "Default label for inline confirmation buttons"
+  },
+
+  "site_info_label": {
+    "message": "Информация за сайта",
+    "description": "Section label for the site information panel"
+  },
+  "site_info_loading": {
+    "message": "Зареждане на информацията за сайта…",
+    "description": "Aria-live status text while site information is being fetched"
+  },
+  "active_theme_label": {
+    "message": "Активна тема",
+    "description": "Label for the active theme row in the site information panel"
+  },
+  "plugins_label": {
+    "message": "Плъгини",
+    "description": "Section label for the plugins group when the count is zero or unknown"
+  },
+  "plugins_with_count": {
+    "message": "Плъгини ($COUNT$)",
+    "description": "Section label for plugins when the total count is known from REST",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "detected_plugins_with_count": {
+    "message": "Открити плъгини ($COUNT$)",
+    "description": "Section label for plugins detected via DOM asset paths when REST count is unavailable",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "login_for_plugin_list": {
+    "message": "Влезте, за да видите пълния списък с плъгини и допълнителна информация.",
+    "description": "Hint shown in the plugins section when the user is logged out"
+  },
+  "nothing_detected": {
+    "message": "Не открихме допълнителна информация.",
+    "description": "Hint shown when no additional site information could be detected"
+  },
+  "login_for_info": {
+    "message": "Влезте за допълнителна информация.",
+    "description": "Hint shown in the theme section when the user is logged out"
+  },
+
+  "update_singular": {
+    "message": "$COUNT$ обновление",
+    "description": "Status badge label for a single pending WordPress update",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "update_plural": {
+    "message": "$COUNT$ обновления",
+    "description": "Status badge label for multiple pending WordPress updates",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "pending_comment_singular": {
+    "message": "$COUNT$ чакащ коментар",
+    "description": "Status badge label for a single comment awaiting moderation",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "pending_comment_plural": {
+    "message": "$COUNT$ чакащи коментара",
+    "description": "Status badge label for multiple comments awaiting moderation",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+
+  "edit_category": {
+    "message": "Редактиране на категорията",
+    "description": "Edit action label when viewing a category archive"
+  },
+  "edit_tag": {
+    "message": "Редактиране на етикета",
+    "description": "Edit action label when viewing a tag archive"
+  },
+  "edit_term": {
+    "message": "Редактиране на термина",
+    "description": "Edit action label when viewing a taxonomy term archive"
+  },
+  "edit_author": {
+    "message": "Редактиране на автора",
+    "description": "Edit action label when viewing an author archive"
+  },
+  "edit_page_fallback": {
+    "message": "Редактиране на страницата",
+    "description": "Fallback edit action label when the post type cannot be determined"
+  },
+  "edit_term_not_resolvable": {
+    "message": "Редактиране на термина (не е достъпно)",
+    "description": "Disabled edit action label when the term cannot be resolved to an edit URL"
+  },
+  "edit_author_not_resolvable": {
+    "message": "Редактиране на автора (не е достъпно)",
+    "description": "Disabled edit action label when the author cannot be resolved to an edit URL"
+  },
+  "nothing_to_edit": {
+    "message": "Няма какво да се редактира",
+    "description": "Disabled edit action label for pages with no editable content (e.g. search results, 404)"
+  },
+  "edit_post_type": {
+    "message": "Редактиране на $TYPE$",
+    "description": "Edit action label prefixed with the post type name (e.g. 'Edit Post', 'Edit Page')",
+    "placeholders": {
+      "type": { "content": "$1" }
+    }
+  },
+
+  "post_type_post": {
+    "message": "публикация",
+    "description": "Display name for the 'post' post type"
+  },
+  "post_type_page": {
+    "message": "страница",
+    "description": "Display name for the 'page' post type"
+  },
+  "post_type_media": {
+    "message": "медиен файл",
+    "description": "Display name for the 'attachment' post type"
+  },
+  "post_type_block_pattern": {
+    "message": "шаблон на блок",
+    "description": "Display name for the 'wp_block' post type (reusable blocks)"
+  },
+  "post_type_template": {
+    "message": "шаблон",
+    "description": "Display name for the 'wp_template' post type"
+  },
+  "post_type_template_part": {
+    "message": "част от шаблон",
+    "description": "Display name for the 'wp_template_part' post type"
+  },
+  "post_type_navigation_menu": {
+    "message": "навигационно меню",
+    "description": "Display name for the 'wp_navigation' post type"
+  },
+  "my_sites_label": {
+    "message": "Моите сайтове",
+    "description": "Header for the saved-sites launcher section"
+  },
+  "my_sites_edit": {
+    "message": "Редактиране",
+    "description": "Toggle that reveals rename/remove controls in the My Sites list"
+  },
+  "my_sites_done": {
+    "message": "Готово",
+    "description": "Toggle that exits edit mode in the My Sites list"
+  },
+  "my_sites_remove": {
+    "message": "Премахване на сайта",
+    "description": "Button that removes a site from the My Sites list"
+  },
+  "my_sites_rename_placeholder": {
+    "message": "Собствено име",
+    "description": "Placeholder/label for the rename field in the My Sites list"
+  },
+  "host_local_dev": {
+    "message": "Локална среда",
+    "description": "Host badge label for a local development environment (the other host labels are brand names and are not translated)"
+  },
+  "edit_blog_template": {
+    "message": "Редактиране на шаблона на блога",
+    "description": "Edit action label on the blog posts index (block theme) — opens the site editor"
+  },
+  "edit_archive_template": {
+    "message": "Редактиране на шаблона на архива",
+    "description": "Edit action label on an archive view (block theme) — opens the site editor"
+  },
+  "edit_unavailable_classic": {
+    "message": "Редактирането не е достъпно (класическа тема)",
+    "description": "Disabled edit label on a template-backed view when the theme is classic (templates are PHP files)"
+  },
+  "edit_template_not_found": {
+    "message": "Шаблонът не е намерен",
+    "description": "Disabled edit label when the block theme has no template matching the current view"
+  },
+  "edit_unavailable": {
+    "message": "Редактирането не е достъпно",
+    "description": "Disabled edit label on a template-backed view when block-theme status can't be determined"
+  }
+}

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/_locales/bg/messages.json
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/_locales/bg/messages.json
@@ -1,0 +1,431 @@
+{
+  "ext_name": {
+    "message": "WordPress Browser Extension",
+    "description": "Extension name shown in browser UI"
+  },
+  "ext_short_name": {
+    "message": "WordPress",
+    "description": "Short name shown where space is limited"
+  },
+  "ext_description": {
+    "message": "Бърз достъп до вашите WordPress сайтове, редактиране на съдържание и инструменти за разработчици. Скрийте админ лентата.",
+    "description": "Extension description shown in the browser's extension store and management pages. The Chrome Web Store shows it as the listing summary and enforces a 132-character limit."
+  },
+  "ext_action_title": {
+    "message": "WordPress Browser Extension",
+    "description": "Tooltip for the toolbar icon button"
+  },
+  "cmd_edit_this_page": {
+    "message": "Редактиране на тази страница в WordPress",
+    "description": "Description for the keyboard shortcut command"
+  },
+
+  "options_page_title": {
+    "message": "WordPress Browser Extension — Настройки",
+    "description": "HTML page title for the options page"
+  },
+  "options_heading": {
+    "message": "WordPress Browser Extension",
+    "description": "H1 heading on the options page"
+  },
+  "options_subtitle": {
+    "message": "Настройки по подразбиране за целия браузър. Изборът за отделните сайтове остава в изскачащия прозорец на лентата с инструменти.",
+    "description": "Subtitle under the options page heading"
+  },
+  "options_admin_bar_section": {
+    "message": "Админ лента",
+    "description": "Section heading for admin bar settings"
+  },
+  "options_hide_admin_bar_label": {
+    "message": "Скриване на админ лентата по подразбиране",
+    "description": "Toggle label for the hide-admin-bar option"
+  },
+  "options_hide_admin_bar_hint": {
+    "message": "Когато е включено, админ лентата е скрита в новите WordPress сайтове. Настройките за отделните сайтове в изскачащия прозорец продължават да имат предимство.",
+    "description": "Hint text describing the hide-admin-bar toggle behavior"
+  },
+  "options_experimental_section": {
+    "message": "Експериментални",
+    "description": "Section heading for experimental features"
+  },
+  "options_site_info_label": {
+    "message": "Показване на панела с информация за сайта",
+    "description": "Toggle label for the site information panel option"
+  },
+  "options_site_info_hint": {
+    "message": "Добавя панел в изскачащия прозорец с активната тема, инсталираните плъгини, името на сайта и REST именните пространства. Разпознаването е евристично — извеждането по пътищата на файловете може да даде дублирания и фалшиви резултати (например mu-plugins и drop-ins). Изключено по подразбиране.",
+    "description": "Hint text describing the site information panel feature"
+  },
+  "options_data_section": {
+    "message": "Данни",
+    "description": "Section heading for data management settings"
+  },
+  "options_reset_label": {
+    "message": "Нулиране на данните на разширението",
+    "description": "Label for the reset/clear data option"
+  },
+  "options_reset_hint": {
+    "message": "Изчиства всички запазени настройки за отделните сайтове, глобалните настройки на тази страница и кешираните резултати „това WordPress сайт ли е“. Полезно при тестване или за започване начисто.",
+    "description": "Hint text describing what the reset action clears"
+  },
+  "options_clear_button": {
+    "message": "Изчистване на всички данни",
+    "description": "Button label to trigger clearing all extension data"
+  },
+  "options_clear_confirm": {
+    "message": "Да се изчистят ли всички данни на разширението?\n\nТова премахва всички запазени настройки за отделните сайтове, глобалните настройки на тази страница, кешираните резултати от разпознаването на WordPress и запазения списък „Моите сайтове“. Действието е необратимо.",
+    "description": "Confirmation dialog text shown before clearing all data"
+  },
+  "options_cleared_success": {
+    "message": "Изчистено.",
+    "description": "Status message shown after successfully clearing extension data"
+  },
+  "options_cleared_error": {
+    "message": "Данните не бяха изчистени. Опитайте отново.",
+    "description": "Status message shown when clearing extension data fails"
+  },
+
+  "toolbar_title_detected": {
+    "message": "Разпознат WordPress",
+    "description": "Toolbar icon tooltip when a WordPress site is detected but the user is not logged in"
+  },
+  "toolbar_title_detected_logged_in": {
+    "message": "Разпознат WordPress — влезли сте",
+    "description": "Toolbar icon tooltip when a WordPress site is detected and the user is logged in"
+  },
+  "toolbar_title_default": {
+    "message": "WordPress Browser Extension",
+    "description": "Default toolbar icon tooltip when no WordPress site is detected"
+  },
+  "admin_bar_hidden_notice": {
+    "message": "[WordPress Browser Extension] Админ лентата е скрита на този сайт. Превключете „Показване на админ лентата“ в изскачащия прозорец на разширението или на страницата с настройки.",
+    "description": "Console info message shown when the admin bar is hidden on a site"
+  },
+
+  "error_view_title": {
+    "message": "Нещо се обърка",
+    "description": "Title shown in the popup error state"
+  },
+  "error_view_description": {
+    "message": "Проверете логовете на service worker-а.",
+    "description": "Description shown in the popup error state"
+  },
+  "not_supported_title": {
+    "message": "Тук няма какво да се провери",
+    "description": "Title shown when the current tab cannot be inspected (e.g. new tab, browser pages)"
+  },
+  "not_supported_description": {
+    "message": "Отворете уебсайт, за да започнете.",
+    "description": "Description shown when the current tab cannot be inspected"
+  },
+  "not_wordpress_title": {
+    "message": "Не е WordPress сайт",
+    "description": "Title shown when the current site is not detected as WordPress"
+  },
+  "not_wordpress_description": {
+    "message": "Не са открити признаци.",
+    "description": "Description shown when the current site is not detected as WordPress"
+  },
+
+  "verb_view": {
+    "message": "Преглед на",
+    "description": "Verb prefix for viewing a published post/page from the WP admin edit screen"
+  },
+  "verb_preview": {
+    "message": "Визуализация на",
+    "description": "Verb prefix for previewing a draft post/page from the WP admin edit screen"
+  },
+  "visit_site": {
+    "message": "Към сайта",
+    "description": "Button label to visit the WordPress site's frontend"
+  },
+  "wordpress_admin": {
+    "message": "WordPress администрация",
+    "description": "Button label to open the WordPress admin dashboard"
+  },
+  "log_in": {
+    "message": "Вход",
+    "description": "Button label to log into a WordPress site"
+  },
+  "log_in_return": {
+    "message": "Вход и връщане към страницата",
+    "description": "Button label to log in and return to the current page"
+  },
+  "show_admin_bar": {
+    "message": "Показване на админ лентата",
+    "description": "Toggle label to show/hide the WordPress admin bar"
+  },
+  "admin_bar_disabled_info": {
+    "message": "Изглежда админ лентата е изключена от вашия профил или от темата, което ограничава това разширение.",
+    "description": "Info text shown when the admin bar cannot be toggled due to profile or theme settings"
+  },
+  "check_profile_link": {
+    "message": "Към профила →",
+    "description": "Link text directing users to their WordPress profile settings"
+  },
+
+  "copy_url_label": {
+    "message": "Копиране на URL",
+    "description": "Aria-label and tooltip for the copy URL button"
+  },
+  "copied_label": {
+    "message": "Копирано",
+    "description": "Aria-label and tooltip for the copy URL button after the URL has been copied"
+  },
+  "open_new_tab_label": {
+    "message": "Отваряне в нов раздел",
+    "description": "Aria-label and tooltip for the open-in-new-tab button"
+  },
+
+  "account_menu_label": {
+    "message": "Меню на профила",
+    "description": "Aria-label for the user account menu button when no display name is available"
+  },
+  "account_menu_for_user": {
+    "message": "Меню на профила за $NAME$",
+    "description": "Aria-label for the user account menu button when a display name is available",
+    "placeholders": {
+      "name": { "content": "$1" }
+    }
+  },
+  "profile_menu_item": {
+    "message": "Профил",
+    "description": "Menu item linking to the user's WordPress profile"
+  },
+  "gravatar_menu_item": {
+    "message": "Gravatar",
+    "description": "Menu item linking to the user's Gravatar profile"
+  },
+  "log_out_button": {
+    "message": "Изход",
+    "description": "Button label to log out of the WordPress site"
+  },
+  "confirm_click_button": {
+    "message": "Натиснете отново за потвърждение",
+    "description": "Button label shown after first click on a destructive action, prompting a second confirmation click"
+  },
+  "super_admin_role": {
+    "message": "Супер администратор",
+    "description": "Role badge label for WordPress multisite super administrators"
+  },
+
+  "new_content_label": {
+    "message": "Създаване",
+    "description": "Section label for the 'New content' action group in the popup"
+  },
+
+  "dev_tools_label": {
+    "message": "Инструменти за разработчици",
+    "description": "Section label for the developer tools group in the popup"
+  },
+  "highlight_blocks_toggle": {
+    "message": "Открояване на блоковете",
+    "description": "Toggle label for the block highlighter developer tool"
+  },
+  "mobile_preview_action": {
+    "message": "Мобилен изглед",
+    "description": "Action label to open the site in mobile preview mode"
+  },
+  "bypass_page_cache_action": {
+    "message": "Заобикаляне на кеша",
+    "description": "Action label to reload the page bypassing the server-side page cache"
+  },
+  "query_monitor_toggle": {
+    "message": "Query Monitor",
+    "description": "Toggle label for the Query Monitor plugin panel"
+  },
+  "clear_site_data_action": {
+    "message": "Изчистване на данните (запазва входа)",
+    "description": "Action label to clear browser site data while preserving the login session"
+  },
+
+  "confirm_label": {
+    "message": "Потвърждаване",
+    "description": "Default label for inline confirmation buttons"
+  },
+
+  "site_info_label": {
+    "message": "Информация за сайта",
+    "description": "Section label for the site information panel"
+  },
+  "site_info_loading": {
+    "message": "Зареждане на информацията за сайта…",
+    "description": "Aria-live status text while site information is being fetched"
+  },
+  "active_theme_label": {
+    "message": "Активна тема",
+    "description": "Label for the active theme row in the site information panel"
+  },
+  "plugins_label": {
+    "message": "Плъгини",
+    "description": "Section label for the plugins group when the count is zero or unknown"
+  },
+  "plugins_with_count": {
+    "message": "Плъгини ($COUNT$)",
+    "description": "Section label for plugins when the total count is known from REST",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "detected_plugins_with_count": {
+    "message": "Открити плъгини ($COUNT$)",
+    "description": "Section label for plugins detected via DOM asset paths when REST count is unavailable",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "login_for_plugin_list": {
+    "message": "Влезте, за да видите пълния списък с плъгини и допълнителна информация.",
+    "description": "Hint shown in the plugins section when the user is logged out"
+  },
+  "nothing_detected": {
+    "message": "Не открихме допълнителна информация.",
+    "description": "Hint shown when no additional site information could be detected"
+  },
+  "login_for_info": {
+    "message": "Влезте за допълнителна информация.",
+    "description": "Hint shown in the theme section when the user is logged out"
+  },
+
+  "update_singular": {
+    "message": "$COUNT$ обновление",
+    "description": "Status badge label for a single pending WordPress update",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "update_plural": {
+    "message": "$COUNT$ обновления",
+    "description": "Status badge label for multiple pending WordPress updates",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "pending_comment_singular": {
+    "message": "$COUNT$ чакащ коментар",
+    "description": "Status badge label for a single comment awaiting moderation",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+  "pending_comment_plural": {
+    "message": "$COUNT$ чакащи коментара",
+    "description": "Status badge label for multiple comments awaiting moderation",
+    "placeholders": {
+      "count": { "content": "$1" }
+    }
+  },
+
+  "edit_category": {
+    "message": "Редактиране на категорията",
+    "description": "Edit action label when viewing a category archive"
+  },
+  "edit_tag": {
+    "message": "Редактиране на етикета",
+    "description": "Edit action label when viewing a tag archive"
+  },
+  "edit_term": {
+    "message": "Редактиране на термина",
+    "description": "Edit action label when viewing a taxonomy term archive"
+  },
+  "edit_author": {
+    "message": "Редактиране на автора",
+    "description": "Edit action label when viewing an author archive"
+  },
+  "edit_page_fallback": {
+    "message": "Редактиране на страницата",
+    "description": "Fallback edit action label when the post type cannot be determined"
+  },
+  "edit_term_not_resolvable": {
+    "message": "Редактиране на термина (не е достъпно)",
+    "description": "Disabled edit action label when the term cannot be resolved to an edit URL"
+  },
+  "edit_author_not_resolvable": {
+    "message": "Редактиране на автора (не е достъпно)",
+    "description": "Disabled edit action label when the author cannot be resolved to an edit URL"
+  },
+  "nothing_to_edit": {
+    "message": "Няма какво да се редактира",
+    "description": "Disabled edit action label for pages with no editable content (e.g. search results, 404)"
+  },
+  "edit_post_type": {
+    "message": "Редактиране на $TYPE$",
+    "description": "Edit action label prefixed with the post type name (e.g. 'Edit Post', 'Edit Page')",
+    "placeholders": {
+      "type": { "content": "$1" }
+    }
+  },
+
+  "post_type_post": {
+    "message": "публикация",
+    "description": "Display name for the 'post' post type"
+  },
+  "post_type_page": {
+    "message": "страница",
+    "description": "Display name for the 'page' post type"
+  },
+  "post_type_media": {
+    "message": "медиен файл",
+    "description": "Display name for the 'attachment' post type"
+  },
+  "post_type_block_pattern": {
+    "message": "шаблон на блок",
+    "description": "Display name for the 'wp_block' post type (reusable blocks)"
+  },
+  "post_type_template": {
+    "message": "шаблон",
+    "description": "Display name for the 'wp_template' post type"
+  },
+  "post_type_template_part": {
+    "message": "част от шаблон",
+    "description": "Display name for the 'wp_template_part' post type"
+  },
+  "post_type_navigation_menu": {
+    "message": "навигационно меню",
+    "description": "Display name for the 'wp_navigation' post type"
+  },
+  "my_sites_label": {
+    "message": "Моите сайтове",
+    "description": "Header for the saved-sites launcher section"
+  },
+  "my_sites_edit": {
+    "message": "Редактиране",
+    "description": "Toggle that reveals rename/remove controls in the My Sites list"
+  },
+  "my_sites_done": {
+    "message": "Готово",
+    "description": "Toggle that exits edit mode in the My Sites list"
+  },
+  "my_sites_remove": {
+    "message": "Премахване на сайта",
+    "description": "Button that removes a site from the My Sites list"
+  },
+  "my_sites_rename_placeholder": {
+    "message": "Собствено име",
+    "description": "Placeholder/label for the rename field in the My Sites list"
+  },
+  "host_local_dev": {
+    "message": "Локална среда",
+    "description": "Host badge label for a local development environment (the other host labels are brand names and are not translated)"
+  },
+  "edit_blog_template": {
+    "message": "Редактиране на шаблона на блога",
+    "description": "Edit action label on the blog posts index (block theme) — opens the site editor"
+  },
+  "edit_archive_template": {
+    "message": "Редактиране на шаблона на архива",
+    "description": "Edit action label on an archive view (block theme) — opens the site editor"
+  },
+  "edit_unavailable_classic": {
+    "message": "Редактирането не е достъпно (класическа тема)",
+    "description": "Disabled edit label on a template-backed view when the theme is classic (templates are PHP files)"
+  },
+  "edit_template_not_found": {
+    "message": "Шаблонът не е намерен",
+    "description": "Disabled edit label when the block theme has no template matching the current view"
+  },
+  "edit_unavailable": {
+    "message": "Редактирането не е достъпно",
+    "description": "Disabled edit label on a template-backed view when block-theme status can't be determined"
+  }
+}


### PR DESCRIPTION
- Adds a Bulgarian (`bg`) catalog under `_locales/`, per the workflow in CONTRIBUTING.md.
- The Safari Resources mirror is regenerated with `scripts/sync-safari.sh` and committed alongside.
- Tested in Chrome with the UI language set to Bulgarian - popup, account menu, options page and toolbar tooltips.