### PR TITLE
Firefox MV3 compatibility (background scripts + gecko settings)

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,12 +12,19 @@
 
 // Pure My Sites store helpers, attached to globalThis.WPMySites — shared with
 // the popup, which loads the same file as a classic script.
-importScripts('lib/my-sites.js');
-
-// REST helpers (globalThis.WPRest). The edit-this-page keyboard shortcut reuses
-// resolveEditUrlSync from here rather than maintaining a second copy of the
-// admin-URL priority chain and its same-origin guard.
-importScripts('lib/rest.js');
+//
+// importScripts() only exists in a real service worker (Chrome's MV3
+// background). Firefox runs this file as an event page instead — a plain
+// script context, not a worker — where importScripts is undefined. There,
+// manifest.json's background.scripts array already loads lib/my-sites.js and
+// lib/rest.js ahead of this file, so the guard below is a no-op on Firefox
+// rather than a missing dependency.
+if (typeof importScripts === 'function') {
+  // REST helpers (globalThis.WPRest). The edit-this-page keyboard shortcut
+  // reuses resolveEditUrlSync from here rather than maintaining a second copy
+  // of the admin-URL priority chain and its same-origin guard.
+  importScripts('lib/my-sites.js', 'lib/rest.js');
+}
 
 // Detection results are cached one storage key per origin (wp_cache_<origin>)
 // rather than a single blob, so a page load reads and writes only its own

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,13 @@
   "author": "Jake Goldman, Partner at Fueled",
   "homepage_url": "https://github.com/WordPress/browser-extension",
 
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "browser-extension@wordpress.org",
+      "strict_min_version": "121.0"
+    }
+  },
+
   "action": {
     "default_title": "__MSG_ext_action_title__",
     "default_icon": {
@@ -23,7 +30,8 @@
   },
 
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": ["lib/my-sites.js", "lib/rest.js", "background.js"]
   },
 
   "content_scripts": [

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
@@ -12,12 +12,19 @@
 
 // Pure My Sites store helpers, attached to globalThis.WPMySites — shared with
 // the popup, which loads the same file as a classic script.
-importScripts('lib/my-sites.js');
-
-// REST helpers (globalThis.WPRest). The edit-this-page keyboard shortcut reuses
-// resolveEditUrlSync from here rather than maintaining a second copy of the
-// admin-URL priority chain and its same-origin guard.
-importScripts('lib/rest.js');
+//
+// importScripts() only exists in a real service worker (Chrome's MV3
+// background). Firefox runs this file as an event page instead — a plain
+// script context, not a worker — where importScripts is undefined. There,
+// manifest.json's background.scripts array already loads lib/my-sites.js and
+// lib/rest.js ahead of this file, so the guard below is a no-op on Firefox
+// rather than a missing dependency.
+if (typeof importScripts === 'function') {
+  // REST helpers (globalThis.WPRest). The edit-this-page keyboard shortcut
+  // reuses resolveEditUrlSync from here rather than maintaining a second copy
+  // of the admin-URL priority chain and its same-origin guard.
+  importScripts('lib/my-sites.js', 'lib/rest.js');
+}
 
 // Detection results are cached one storage key per origin (wp_cache_<origin>)
 // rather than a single blob, so a page load reads and writes only its own

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/manifest.json
@@ -8,6 +8,13 @@
   "author": "Jake Goldman, Partner at Fueled",
   "homepage_url": "https://github.com/WordPress/browser-extension",
 
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "browser-extension@wordpress.org",
+      "strict_min_version": "121.0"
+    }
+  },
+
   "action": {
     "default_title": "__MSG_ext_action_title__",
     "default_icon": {
@@ -23,7 +30,8 @@
   },
 
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": ["lib/my-sites.js", "lib/rest.js", "background.js"]
   },
 
   "content_scripts": [


### PR DESCRIPTION
Addresses the Firefox Add-ons (AMO) item on the roadmap — the next post-1.0 target, flagged there as needing "a manifest v2/v3 compatibility audit; Firefox's WebExtension surface diverges from Chromium in a few places."

**Changes:**
- `manifest.json`: adds `background.scripts` alongside `service_worker` — Chrome uses `service_worker`, Firefox (121+) uses `scripts` as an event page. Both keys can coexist safely per current Firefox/Chrome behavior.
- `manifest.json`: adds `browser_specific_settings.gecko` for AMO signing. **Note:** the `id` value (`browser-extension@wordpress.org`) is a placeholder — this needs to be a real, permanent identifier the WordPress Foundation controls, since AMO uses it to track the extension across updates. Please confirm the actual value before merge.
- `background.js`: guards the `importScripts()` calls, since `importScripts` is a `WorkerGlobalScope` method unavailable in Firefox's event-page context (a plain script, not a worker). Firefox loads the two dependency files via `manifest.json`'s `scripts` array instead, ahead of `background.js`.
- Safari resource mirror (`safari/.../Resources/`) synced to match, via the existing `scripts/sync-safari.sh`.

**Tested:**
- Full test suite passes (`test/npm test`), `npm run build` clean.
- Manually verified in Firefox desktop on Linux, loaded as a temporary add-on (`about:debugging`): WordPress detection, popup, admin bar shortcuts (edit/view/profile/logout), Mobile Preview, cache-busting, Clear Site Data (Keep Login), and Highlight Blocks all confirmed working correctly.

**Known gap, not addressed here:** Firefox for Android has no `windows` API, so Mobile Preview (which calls `chrome.windows.create`) will silently no-op there rather than open a preview window. Scoping that out of this PR since it's Android-specific and this PR is focused on desktop Firefox compatibility — happy to follow up separately if that's wanted.