### PR TITLE
Detection: gate the fresh fetch on its final response URL

### DIFF
--- a/content.js
+++ b/content.js
@@ -187,6 +187,19 @@
 
   // -- Popup messaging -----------------------------------------------------
 
+  // Does `resUrl` — a fetch's final URL, after redirects — still name the
+  // document `target` describes? Origin and pathname only; query and hash feed
+  // nothing in detection. Absent or unparseable counts as a mismatch.
+  function isSameDocumentResponse(resUrl, target) {
+    if (!resUrl) return false;
+    try {
+      const final = new URL(resUrl, target.href);
+      return final.origin === target.origin && final.pathname === target.pathname;
+    } catch (_) {
+      return false;
+    }
+  }
+
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     if (!msg) return;
 
@@ -216,7 +229,12 @@
       // auth cookie return logged-in HTML here; ones that don't return the
       // same stale response, in which case the popup falls back to a reload
       // prompt.
-      fetch(location.href, {
+      //
+      // Capture the target once: the gate below and the values handed to
+      // detection must describe one document, and `location` can move under a
+      // pushState navigation mid-fetch.
+      const target = new URL(location.href);
+      fetch(target.href, {
         credentials: 'include',
         cache: 'no-store',
         headers: { 'Cache-Control': 'no-cache' },
@@ -224,16 +242,23 @@
       })
         .then(async (res) => {
           if (!res.ok) return sendResponse({ detection: null });
+          // A redirect can land this credentialed request on a document the
+          // page load never saw — a login wall, another install on the host,
+          // another origin. The popup keys what comes back to the captured tab,
+          // so parsing it would attribute another install's admin bar and base
+          // to this tab. Fail closed; the popup keeps what it rendered.
+          if (!isSameDocumentResponse(res.url, target)) {
+            return sendResponse({ detection: null });
+          }
           const html = await res.text();
           const doc = new DOMParser().parseFromString(html, 'text/html');
-          // Parsed via DOMParser → no defaultView. Pass the live origin and
-          // pathname explicitly: the origin so the +New same-origin filter
+          // Parsed via DOMParser → no defaultView. Pass the captured origin
+          // and pathname explicitly: the origin so the +New same-origin filter
           // can validate hrefs, the pathname so the wp-admin base fallback
-          // works (the fetch is of location.href, so both describe the
-          // parsed document).
+          // works (the gate above confirmed both describe this document).
           const det = globalThis.WPDetect.detectWordPress(doc, {
-            origin: location.origin,
-            pathname: location.pathname,
+            origin: target.origin,
+            pathname: target.pathname,
           });
           if (!det.context.isLoggedIn) {
             det.context.isLoggedIn =

--- a/content.js
+++ b/content.js
@@ -188,13 +188,17 @@
   // -- Popup messaging -----------------------------------------------------
 
   // Does `resUrl` — a fetch's final URL, after redirects — still name the
-  // document `target` describes? Origin and pathname only; query and hash feed
-  // nothing in detection. Absent or unparseable counts as a mismatch.
+  // document `target` describes? Origin, pathname, AND query must all match:
+  // on plain permalinks the query selects the document (?p=1 and ?p=2 are
+  // different posts). Only the fragment sits outside a document's identity.
+  // Absent or unparseable counts as a mismatch.
   function isSameDocumentResponse(resUrl, target) {
     if (!resUrl) return false;
     try {
       const final = new URL(resUrl, target.href);
-      return final.origin === target.origin && final.pathname === target.pathname;
+      return final.origin === target.origin
+        && final.pathname === target.pathname
+        && final.search === target.search;
     } catch (_) {
       return false;
     }

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/content.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/content.js
@@ -187,6 +187,19 @@
 
   // -- Popup messaging -----------------------------------------------------
 
+  // Does `resUrl` — a fetch's final URL, after redirects — still name the
+  // document `target` describes? Origin and pathname only; query and hash feed
+  // nothing in detection. Absent or unparseable counts as a mismatch.
+  function isSameDocumentResponse(resUrl, target) {
+    if (!resUrl) return false;
+    try {
+      const final = new URL(resUrl, target.href);
+      return final.origin === target.origin && final.pathname === target.pathname;
+    } catch (_) {
+      return false;
+    }
+  }
+
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     if (!msg) return;
 
@@ -216,7 +229,12 @@
       // auth cookie return logged-in HTML here; ones that don't return the
       // same stale response, in which case the popup falls back to a reload
       // prompt.
-      fetch(location.href, {
+      //
+      // Capture the target once: the gate below and the values handed to
+      // detection must describe one document, and `location` can move under a
+      // pushState navigation mid-fetch.
+      const target = new URL(location.href);
+      fetch(target.href, {
         credentials: 'include',
         cache: 'no-store',
         headers: { 'Cache-Control': 'no-cache' },
@@ -224,16 +242,23 @@
       })
         .then(async (res) => {
           if (!res.ok) return sendResponse({ detection: null });
+          // A redirect can land this credentialed request on a document the
+          // page load never saw — a login wall, another install on the host,
+          // another origin. The popup keys what comes back to the captured tab,
+          // so parsing it would attribute another install's admin bar and base
+          // to this tab. Fail closed; the popup keeps what it rendered.
+          if (!isSameDocumentResponse(res.url, target)) {
+            return sendResponse({ detection: null });
+          }
           const html = await res.text();
           const doc = new DOMParser().parseFromString(html, 'text/html');
-          // Parsed via DOMParser → no defaultView. Pass the live origin and
-          // pathname explicitly: the origin so the +New same-origin filter
+          // Parsed via DOMParser → no defaultView. Pass the captured origin
+          // and pathname explicitly: the origin so the +New same-origin filter
           // can validate hrefs, the pathname so the wp-admin base fallback
-          // works (the fetch is of location.href, so both describe the
-          // parsed document).
+          // works (the gate above confirmed both describe this document).
           const det = globalThis.WPDetect.detectWordPress(doc, {
-            origin: location.origin,
-            pathname: location.pathname,
+            origin: target.origin,
+            pathname: target.pathname,
           });
           if (!det.context.isLoggedIn) {
             det.context.isLoggedIn =

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/content.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/content.js
@@ -188,13 +188,17 @@
   // -- Popup messaging -----------------------------------------------------
 
   // Does `resUrl` — a fetch's final URL, after redirects — still name the
-  // document `target` describes? Origin and pathname only; query and hash feed
-  // nothing in detection. Absent or unparseable counts as a mismatch.
+  // document `target` describes? Origin, pathname, AND query must all match:
+  // on plain permalinks the query selects the document (?p=1 and ?p=2 are
+  // different posts). Only the fragment sits outside a document's identity.
+  // Absent or unparseable counts as a mismatch.
   function isSameDocumentResponse(resUrl, target) {
     if (!resUrl) return false;
     try {
       const final = new URL(resUrl, target.href);
-      return final.origin === target.origin && final.pathname === target.pathname;
+      return final.origin === target.origin
+        && final.pathname === target.pathname
+        && final.search === target.search;
     } catch (_) {
       return false;
     }

--- a/test/content-lifecycle.js
+++ b/test/content-lifecycle.js
@@ -335,8 +335,8 @@ async function main() {
     // Drives one GET_FRESH_DETECTION round trip against a fetch stub that
     // reports `responseUrl` as its final URL. `beforeResolve` runs while the
     // fetch is still in flight, so a test can move `location` under it.
-    async function freshFetch(responseUrl, { html = WP_LOGGED_IN_PAGE, beforeResolve } = {}) {
-      const page = makePage(html, { url: PAGE_URL });
+    async function freshFetch(responseUrl, { html = WP_LOGGED_IN_PAGE, beforeResolve, pageUrl = PAGE_URL } = {}) {
+      const page = makePage(html, { url: pageUrl });
       page.runContent();
       await settle();
 
@@ -383,10 +383,17 @@ async function main() {
     const empty = await freshFetch('');
     assert(empty.resp.detection === null, 'an empty response URL is refused');
 
-    // Query and hash aren't part of the document's identity.
-    const requery = await freshFetch(`${PAGE_URL}?utm_source=`);
-    assert(!!requery.resp.detection && requery.resp.detection.isWordPress,
-      'a redirect differing only in query string is parsed');
+    // On plain permalinks the query SELECTS the document: ?p=1 and ?p=2 are
+    // different posts, so a response whose query differs is another page and
+    // is refused. Only the fragment sits outside a document's identity.
+    const otherPost = await freshFetch('https://example.com/index.php?p=2', {
+      pageUrl: 'https://example.com/index.php?p=1',
+    });
+    assert(otherPost.resp.detection === null,
+      'a redirect to a different document-selecting query is refused');
+    const fragment = await freshFetch(`${PAGE_URL}#comments`);
+    assert(!!fragment.resp.detection && fragment.resp.detection.isWordPress,
+      'a fragment-only difference is still the same document');
 
     // A pushState mid-flight must not retarget the gate or detection's input.
     const seen = [];

--- a/test/content-lifecycle.js
+++ b/test/content-lifecycle.js
@@ -300,7 +300,13 @@ async function main() {
     // for the duration, restoring both after.
     const savedFetch = globalThis.fetch;
     const savedParser = globalThis.DOMParser;
-    globalThis.fetch = async () => ({ ok: true, text: async () => ADMIN_PAGE });
+    // `url` is the fetch's final (post-redirect) response URL; the handler
+    // refuses to parse a response that doesn't attest to the requested one.
+    globalThis.fetch = async () => ({
+      ok: true,
+      url: `https://example.com${ADMIN_PATH}`,
+      text: async () => ADMIN_PAGE,
+    });
     globalThis.DOMParser = page.ctx.DOMParser;
     try {
       const fresh = await new Promise((resolve) => {
@@ -318,6 +324,86 @@ async function main() {
       globalThis.fetch = savedFetch;
       globalThis.DOMParser = savedParser;
     }
+  }
+
+  // --- 45. GET_FRESH_DETECTION refuses redirected responses --------------
+  {
+    console.log('\n[45] fresh fetch is gated on the final response URL (#109)');
+    const PAGE_PATH = '/blog/hello-world/';
+    const PAGE_URL = `https://example.com${PAGE_PATH}`;
+
+    // Drives one GET_FRESH_DETECTION round trip against a fetch stub that
+    // reports `responseUrl` as its final URL. `beforeResolve` runs while the
+    // fetch is still in flight, so a test can move `location` under it.
+    async function freshFetch(responseUrl, { html = WP_LOGGED_IN_PAGE, beforeResolve } = {}) {
+      const page = makePage(html, { url: PAGE_URL });
+      page.runContent();
+      await settle();
+
+      const requested = [];
+      const savedFetch = globalThis.fetch;
+      const savedParser = globalThis.DOMParser;
+      globalThis.fetch = async (input) => {
+        requested.push(String(input));
+        if (beforeResolve) beforeResolve(page);
+        const res = { ok: true, text: async () => html };
+        // No URL reported is the property missing, not ''.
+        if (responseUrl !== undefined) res.url = responseUrl;
+        return res;
+      };
+      globalThis.DOMParser = page.ctx.DOMParser;
+      try {
+        const resp = await new Promise((resolve) => {
+          for (const fn of page.listeners) fn({ type: 'GET_FRESH_DETECTION' }, {}, resolve);
+        });
+        return { resp, requested };
+      } finally {
+        globalThis.fetch = savedFetch;
+        globalThis.DOMParser = savedParser;
+      }
+    }
+
+    const same = await freshFetch(PAGE_URL);
+    assert(same.requested[0] === PAGE_URL, 'fetches the page it captured');
+    assert(!!same.resp.detection && same.resp.detection.isWordPress,
+      'an unredirected response is parsed');
+
+    // The login wall a stale session lands on: WordPress markup, so without
+    // the gate its admin bar merges straight into this tab's resolution.
+    const login = await freshFetch('https://example.com/wp-login.php');
+    assert(login.resp.detection === null,
+      'a same-origin redirect to another document is refused');
+
+    const offsite = await freshFetch('https://cdn.example.net/blog/hello-world/');
+    assert(offsite.resp.detection === null, 'a cross-origin redirect is refused');
+
+    const unattested = await freshFetch(undefined);
+    assert(unattested.resp.detection === null,
+      'a response with no URL is refused');
+    const empty = await freshFetch('');
+    assert(empty.resp.detection === null, 'an empty response URL is refused');
+
+    // Query and hash aren't part of the document's identity.
+    const requery = await freshFetch(`${PAGE_URL}?utm_source=`);
+    assert(!!requery.resp.detection && requery.resp.detection.isWordPress,
+      'a redirect differing only in query string is parsed');
+
+    // A pushState mid-flight must not retarget the gate or detection's input.
+    const seen = [];
+    const moved = await freshFetch(PAGE_URL, {
+      beforeResolve: (page) => {
+        const orig = page.ctx.WPDetect.detectWordPress;
+        page.ctx.WPDetect.detectWordPress = (doc, opts) => {
+          seen.push(opts || {});
+          return orig(doc, opts);
+        };
+        page.ctx.history.pushState({}, '', '/blog/second-post/');
+      },
+    });
+    assert(!!moved.resp.detection && moved.resp.detection.isWordPress,
+      'a same-document navigation mid-flight does not invalidate the response');
+    assert(seen.length === 1 && seen[0].pathname === PAGE_PATH,
+      'detection still receives the pathname captured at request time');
   }
 
   console.log(`\n${failures === 0 ? 'Content lifecycle tests passed.' : failures + ' failure(s).'}`);


### PR DESCRIPTION
Fixes #109.

## What

The popup's credentialed re-fetch (`GET_FRESH_DETECTION`) parsed whatever came back, without checking it was still the same page. If the server redirects - to a login page, to another install on the same host, or to another origin - the popup would read that page's admin bar and treat it as this tab's: admin bar links, sign-out nonce, and account details.

## How

- Check the response's final URL before parsing. Origin, pathname, and query must match what was requested; only the fragment is ignored. On plain permalinks the query selects the document, so `?p=1` and `?p=2` are different pages. No URL, or one that won't parse, is treated as a mismatch.
- On a mismatch, return `null`. The popup already handles that: it keeps what it has rendered, and nothing is pushed to the background.
- Read the target URL once before the fetch and use it for both the check and the origin/pathname passed to detection, so a `pushState` mid-fetch can't change either.

Only this handler. `RESOLVE_HOST_HEADERS` has the same gap - separate issue, not this PR.

## Test

New `content-lifecycle.js` block [45] runs the real handler against a stubbed fetch:

- normal response → parsed
- redirect to a different document-selecting query → refused
- fragment-only difference → parsed
- redirect to another page on the same origin → refused
- redirect to another origin → refused
- response with no URL / empty URL → refused
- `pushState` mid-fetch → gate still passes, detection still gets the original pathname

## AI Usage

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with implementation and drafting tests
