### PR TITLE
Detection: derive install bases from front-controller REST roots

### DIFF
--- a/lib/detect.js
+++ b/lib/detect.js
@@ -519,12 +519,27 @@
       // base (without this, a slashless root link would mint a bogus
       // <origin>/wp-json base). Decoded first: %77p-json IS wp-json, and the
       // storage layer canonicalizes it that way, so an encoded link must not
-      // smuggle the route past this check into a stored /wp-json base. Plain
-      // permalinks keep the route in the query string, so the path already
-      // is the base.
+      // smuggle the route past this check into a stored /wp-json base.
       let path = decodeUnreservedPercent(rootUrl.pathname).replace(/\/+$/, '');
+      // Only a link that proved itself a route — terminal /wp-json, or a
+      // rest_route query — may give up a trailing segment below; an
+      // unrecognized (filtered, hardened) root keeps its path verbatim
+      // rather than guessing where the route starts.
+      let restShaped = false;
       if (path.endsWith('/wp-json')) {
         path = path.slice(0, -'/wp-json'.length).replace(/\/+$/, '');
+        restShaped = true;
+      } else if (rootUrl.searchParams.has('rest_route')) {
+        restShaped = true;
+      }
+      // rest_url() can print the root through the front controller
+      // (/index.php/wp-json/ on index permalinks, /index.php?rest_route=/ on
+      // plain ones): index.php dispatches AT the base, so leaving it in keys
+      // My Sites at <origin>/index.php and sends every link through it.
+      // Ambiguity decided here: an install in a directory literally named
+      // index.php prints the same root, and loses to the common case.
+      if (restShaped && path.endsWith('/index.php')) {
+        path = path.slice(0, -'/index.php'.length).replace(/\/+$/, '');
       }
       return {
         baseUrl: path ? `${rootUrl.origin}${path}` : rootUrl.origin,

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/lib/detect.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/lib/detect.js
@@ -519,12 +519,27 @@
       // base (without this, a slashless root link would mint a bogus
       // <origin>/wp-json base). Decoded first: %77p-json IS wp-json, and the
       // storage layer canonicalizes it that way, so an encoded link must not
-      // smuggle the route past this check into a stored /wp-json base. Plain
-      // permalinks keep the route in the query string, so the path already
-      // is the base.
+      // smuggle the route past this check into a stored /wp-json base.
       let path = decodeUnreservedPercent(rootUrl.pathname).replace(/\/+$/, '');
+      // Only a link that proved itself a route — terminal /wp-json, or a
+      // rest_route query — may give up a trailing segment below; an
+      // unrecognized (filtered, hardened) root keeps its path verbatim
+      // rather than guessing where the route starts.
+      let restShaped = false;
       if (path.endsWith('/wp-json')) {
         path = path.slice(0, -'/wp-json'.length).replace(/\/+$/, '');
+        restShaped = true;
+      } else if (rootUrl.searchParams.has('rest_route')) {
+        restShaped = true;
+      }
+      // rest_url() can print the root through the front controller
+      // (/index.php/wp-json/ on index permalinks, /index.php?rest_route=/ on
+      // plain ones): index.php dispatches AT the base, so leaving it in keys
+      // My Sites at <origin>/index.php and sends every link through it.
+      // Ambiguity decided here: an install in a directory literally named
+      // index.php prints the same root, and loses to the common case.
+      if (restShaped && path.endsWith('/index.php')) {
+        path = path.slice(0, -'/index.php'.length).replace(/\/+$/, '');
       }
       return {
         baseUrl: path ? `${rootUrl.origin}${path}` : rootUrl.origin,

--- a/test/background-storage.js
+++ b/test/background-storage.js
@@ -748,6 +748,21 @@ async function main() {
       assert(!!literalWpJson[`${HOST}/wp-json`] && Object.keys(literalWpJson).length === 1,
         'pipeline: an install literally based at /wp-json still records its own row');
 
+      // Front-controller REST roots (#107), real pipeline: these used to key
+      // a row at <base>/index.php, with admin links through the dispatcher.
+      for (const shape of ['/index.php/wp-json/', '/index.php/wp-json', '/index.php?rest_route=/']) {
+        const store = await pipeline(HOST + shape);
+        const keys = Object.keys(store);
+        assert(!!store[HOST] && keys.length === 1,
+          `pipeline: root ${shape} records the origin`);
+        assert(keys.every((k) => !k.endsWith('/index.php')),
+          `pipeline: root ${shape} mints no /index.php-suffixed key`);
+      }
+      for (const shape of ['/index.php/wp-json/', '/index.php?rest_route=/']) {
+        const store = await pipeline(SA + shape);
+        assert(!!store[SA] && Object.keys(store).length === 1,
+          `pipeline: subdirectory /siteA${shape} records the /siteA install`);
+      }
     }
     {
       // #102: the oEmbed link is a detection signal only. A logged-in page

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -964,6 +964,44 @@ async function main() {
       derive('https://example.com', 'https://example.com/?rest_route=/')
         === 'https://example.com',
       'root install, plain permalinks → bare origin');
+    // Front-controller REST roots (#107): index.php dispatches AT the install
+    // base, so it is never part of it — left in, admin links point at
+    // <base>/index.php/wp-admin/ and My Sites keys a row there.
+    assert(
+      derive('https://example.com', 'https://example.com/index.php/wp-json/')
+        === 'https://example.com',
+      'index permalinks, root: /index.php/wp-json/ → bare origin');
+    assert(
+      derive('https://example.com', 'https://example.com/index.php/wp-json')
+        === 'https://example.com',
+      'index permalinks, root, slashless: /index.php/wp-json → bare origin');
+    assert(
+      derive('https://example.com', 'https://example.com/wordpress/index.php/wp-json/')
+        === 'https://example.com/wordpress',
+      'index permalinks, subdirectory: /wordpress/index.php/wp-json/ → /wordpress');
+    assert(
+      derive('https://example.com', 'https://example.com/index.php?rest_route=/')
+        === 'https://example.com',
+      'plain permalinks through the front controller: /index.php?rest_route=/ → bare origin');
+    assert(
+      derive('https://example.com', 'https://example.com/wordpress/index.php?rest_route=/')
+        === 'https://example.com/wordpress',
+      'front controller under a subdirectory: /wordpress/index.php?rest_route=/ → /wordpress');
+    assert(
+      derive('https://example.com', 'https://example.com/%69ndex.php/wp-json/')
+        === 'https://example.com',
+      'encoded front controller decodes before the check: /%69ndex.php/wp-json/ → bare origin');
+    // The tradeoff: a root install on index permalinks and an install inside
+    // a directory named index.php print the same root, and only one can win.
+    assert(
+      derive('https://example.com', 'https://example.com/index.php/index.php/wp-json/')
+        === 'https://example.com/index.php',
+      'an install genuinely based at /index.php derives from /index.php/index.php/wp-json/');
+    // An unrecognized root shape keeps its path — no guessing.
+    assert(
+      derive('https://example.com', 'https://example.com/index.php')
+        === 'https://example.com/index.php',
+      'a REST root with no recognizable route shape keeps its path verbatim');
     assert(
       derive('https://example.com', 'https://attacker.example/wp-json/')
         === 'https://example.com',
@@ -1543,6 +1581,14 @@ async function main() {
     assert(derive(ORIGIN, `${ORIGIN}/wordpress/wp-json/`, null).evidence === 'rest'
       && derive(ORIGIN, null, '/wordpress/wp-admin/').evidence === 'admin-path',
       'subdirectory bases report their provenance the same way');
+
+    // Front-controller roots (#107) confirm the root install, where before
+    // they confirmed <origin>/index.php.
+    const frontRoot = derive(ORIGIN, `${ORIGIN}/index.php/wp-json/`, null);
+    const frontPlain = derive(ORIGIN, `${ORIGIN}/index.php?rest_route=/`, null);
+    assert(frontRoot.baseUrl === ORIGIN && frontRoot.evidence === 'rest'
+      && frontPlain.baseUrl === ORIGIN && frontPlain.evidence === 'rest',
+      'front-controller REST roots confirm the root install, not an /index.php base');
 
     // Values that prove nothing must not claim evidence, or the background's
     // My Sites gate would accept a forged root.


### PR DESCRIPTION
Fixes #107.

## What

`rest_url()` can print the REST root through the front controller: `/index.php/wp-json/` on index permalinks, `/index.php?rest_route=/` on plain ones. `deriveBase` stripped only a terminal `/wp-json`, so these derived a base ending in `/index.php` - My Sites keyed a row there and links pointed at `<base>/index.php/wp-admin/`.

## How

Strip a terminal `/index.php` too, but only from a link that proved itself a route: a terminal segment-exact `/wp-json`, or a `rest_route` param. Unrecognized roots keep their path rather than guessing where the route starts. Runs after `decodeUnreservedPercent`, so `/%69ndex.php/wp-json/` is caught like `%77p-json` already was.

The ambiguity: `/index.php/wp-json/` is what both a root install on index permalinks and an install in a directory named `index.php` print. REST evidence can't separate them, so the common case wins - the latter still derives from its own `/index.php/index.php/wp-json/` root.

`deriveBase` only; `evidenceBackedBase` re-derives through it, so nothing changes on the My Sites side.

## Test

Smoke `[25]` covers both shapes at root and subdirectory, slashless, encoded, the install genuinely at `/index.php`, and a root with no route shape. `[45]` covers provenance. `background-storage.js` runs the real pipeline: each shape records the install's own key, no `/index.php` row.

## AI Usage

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Assisting with implementation and drafting tests