### PR TITLE
Host badge: re-validate a cached host on the 90-day clock; retry a missing host after 7 days

### DIFF
--- a/background.js
+++ b/background.js
@@ -34,7 +34,15 @@ const CACHE_PREFIX = 'wp_cache_';
 const LEGACY_CACHE_KEY = 'wp_detection_cache_v1';
 const REFRESH_INTERVAL      = 7 * 24 * 60 * 60 * 1000;  // 1 week
 const PURGE_AFTER           = 28 * 24 * 60 * 60 * 1000;  // 4 weeks
+// Host badge clocks (#121). A cached host is re-validated every
+// HOST_REFRESH_INTERVAL so a badge cached wrong (a pre-#115 redirect follow,
+// or a site that since moved hosts) doesn't persist indefinitely. A missing
+// host retries every HOST_RETRY_INTERVAL: shorter, so a one-off probe
+// rejection (the #115 same-document gate) doesn't suppress the badge for
+// three months, but not per page load, since most self-hosted sites carry no
+// host header at all.
 const HOST_REFRESH_INTERVAL = 90 * 24 * 60 * 60 * 1000;  // 90 days
+const HOST_RETRY_INTERVAL   = 7 * 24 * 60 * 60 * 1000;   // 7 days
 
 // --- Cache helpers (one storage key per origin) ---------------------------
 
@@ -600,11 +608,15 @@ async function handleDetection(msg, sender) {
     hostCheckedAt,
   };
 
-  // If WordPress but host is still unknown and we haven't checked
-  // recently, ask the content script to inspect response headers.
-  // Resolve before the first write so we don't write twice.
-  const needsHostCheck = entry.isWordPress && !entry.host &&
-    (!entry.hostCheckedAt || (now - entry.hostCheckedAt) > HOST_REFRESH_INTERVAL);
+  // If WordPress and the host badge is due, ask the content script to
+  // inspect response headers: a cached host on the refresh clock, a missing
+  // one on the shorter retry clock (see the interval constants). The probe's
+  // answer replaces whatever was cached, null included, so the badge always
+  // reflects the latest probe. Resolve before the first write so we don't
+  // write twice.
+  const hostInterval = entry.host ? HOST_REFRESH_INTERVAL : HOST_RETRY_INTERVAL;
+  const needsHostCheck = entry.isWordPress &&
+    (!entry.hostCheckedAt || (now - entry.hostCheckedAt) > hostInterval);
 
   if (needsHostCheck) {
     try {

--- a/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
+++ b/safari/WordPress Browser Extension/WordPress Browser Extension Extension/Resources/background.js
@@ -34,7 +34,15 @@ const CACHE_PREFIX = 'wp_cache_';
 const LEGACY_CACHE_KEY = 'wp_detection_cache_v1';
 const REFRESH_INTERVAL      = 7 * 24 * 60 * 60 * 1000;  // 1 week
 const PURGE_AFTER           = 28 * 24 * 60 * 60 * 1000;  // 4 weeks
+// Host badge clocks (#121). A cached host is re-validated every
+// HOST_REFRESH_INTERVAL so a badge cached wrong (a pre-#115 redirect follow,
+// or a site that since moved hosts) doesn't persist indefinitely. A missing
+// host retries every HOST_RETRY_INTERVAL: shorter, so a one-off probe
+// rejection (the #115 same-document gate) doesn't suppress the badge for
+// three months, but not per page load, since most self-hosted sites carry no
+// host header at all.
 const HOST_REFRESH_INTERVAL = 90 * 24 * 60 * 60 * 1000;  // 90 days
+const HOST_RETRY_INTERVAL   = 7 * 24 * 60 * 60 * 1000;   // 7 days
 
 // --- Cache helpers (one storage key per origin) ---------------------------
 
@@ -600,11 +608,15 @@ async function handleDetection(msg, sender) {
     hostCheckedAt,
   };
 
-  // If WordPress but host is still unknown and we haven't checked
-  // recently, ask the content script to inspect response headers.
-  // Resolve before the first write so we don't write twice.
-  const needsHostCheck = entry.isWordPress && !entry.host &&
-    (!entry.hostCheckedAt || (now - entry.hostCheckedAt) > HOST_REFRESH_INTERVAL);
+  // If WordPress and the host badge is due, ask the content script to
+  // inspect response headers: a cached host on the refresh clock, a missing
+  // one on the shorter retry clock (see the interval constants). The probe's
+  // answer replaces whatever was cached, null included, so the badge always
+  // reflects the latest probe. Resolve before the first write so we don't
+  // write twice.
+  const hostInterval = entry.host ? HOST_REFRESH_INTERVAL : HOST_RETRY_INTERVAL;
+  const needsHostCheck = entry.isWordPress &&
+    (!entry.hostCheckedAt || (now - entry.hostCheckedAt) > hostInterval);
 
   if (needsHostCheck) {
     try {

--- a/test/background-storage.js
+++ b/test/background-storage.js
@@ -79,7 +79,7 @@ function makeStorage(initial = {}) {
 
 /** Loads background.js with stubs; returns the captured onMessage listener
  * plus the storage handle. */
-function loadBackground(storage) {
+function loadBackground(storage, overrides = {}) {
   // The lib IIFEs attach to the passed globalThis object.
   const libCtx = {};
   new Function('globalThis', mySitesSrc)(libCtx);
@@ -109,7 +109,7 @@ function loadBackground(storage) {
     tabs: {
       onUpdated: noopEvent,
       query: async () => [],
-      sendMessage: async () => ({}),
+      sendMessage: overrides.sendMessage || (async () => ({})),
       update: async (tabId, opts) => {
         if (typeof tabId === 'number' && opts && opts.url) {
           winState.navigated.push({ tabId, url: opts.url });
@@ -825,6 +825,70 @@ async function main() {
         assert(Object.keys(store).length === 2, `${label}: no record moved, none lost`);
       }
     }
+  }
+
+  // --- 42. Host badge re-validation (#121) -------------------------------
+  {
+    console.log('\n[42] host badge: a cached host re-validates on the 90-day clock; a missing host retries sooner (#121)');
+    const DAY = 24 * 60 * 60 * 1000;
+    const ORIGIN = 'https://h.example';
+    const KEY = `wp_cache_${ORIGIN}`;
+    const now = Date.now();
+    const seed = (host, hostCheckedAt) => ({
+      origin: ORIGIN, isWordPress: true, confidence: 100, signals: ['rest-api-link'],
+      isLoggedIn: false, checkedAt: now, lastSeen: now, host, hostCheckedAt,
+    });
+    // One page load against a seeded cache entry with the header probe
+    // stubbed; reports whether the probe ran and what got stored.
+    const load = async (entry, probe, hostFromDOM = null) => {
+      const probes = [];
+      const storage = makeStorage({ [KEY]: entry });
+      const { send } = loadBackground(storage, {
+        sendMessage: async (_tabId, msg) => {
+          if (msg?.type === 'RESOLVE_HOST_HEADERS') probes.push(msg.type);
+          return probe();
+        },
+      });
+      await send({
+        type: 'WP_DETECTION',
+        detection: { isWordPress: true, confidence: 100, signals: ['rest-api-link'], context: { isLoggedIn: false } },
+        hostFromDOM,
+      }, { url: `${ORIGIN}/page`, origin: ORIGIN, tab: { id: 9, url: `${ORIGIN}/page` } });
+      await settle();
+      return { probed: probes.length, stored: storage.read(KEY) };
+    };
+
+    // A cached host past the refresh interval is re-probed, and the probe's
+    // answer replaces it: a wrong badge no longer persists indefinitely.
+    let r = await load(seed('wpengine', now - 91 * DAY), async () => ({ host: 'kinsta' }));
+    assert(r.probed === 1, 'stale cached host: header probe runs');
+    assert(r.stored.host === 'kinsta', 'stale cached host: probe result replaces the cached badge');
+    assert(r.stored.hostCheckedAt >= now, 'stale cached host: clock restarts');
+
+    // A fresh cached host is left alone: no probe per page load.
+    r = await load(seed('wpengine', now - 1 * DAY), async () => ({ host: 'kinsta' }));
+    assert(r.probed === 0 && r.stored.host === 'wpengine', 'fresh cached host: no probe, badge kept');
+
+    // Latest probe wins: a null answer on re-validation clears the badge
+    // (a site that moved to a host with no header signature).
+    r = await load(seed('wpengine', now - 91 * DAY), async () => ({ host: null }));
+    assert(r.probed === 1 && r.stored.host === null, 'stale cached host, null probe: badge cleared');
+
+    // A missing host retries on the shorter clock, not the 90-day one, so a
+    // one-off probe rejection (#115 gate) doesn't suppress the badge for months.
+    r = await load(seed(null, now - 8 * DAY), async () => ({ host: 'kinsta' }));
+    assert(r.probed === 1 && r.stored.host === 'kinsta', 'missing host past the retry interval: probe runs and sets the badge');
+    r = await load(seed(null, now - 1 * DAY), async () => ({ host: 'kinsta' }));
+    assert(r.probed === 0 && r.stored.host === null, 'missing host inside the retry interval: no probe');
+
+    // A DOM/origin host signal on the current page wins outright: no probe.
+    r = await load(seed('wpengine', now - 91 * DAY), async () => ({ host: 'kinsta' }), 'selfhosted');
+    assert(r.probed === 0 && r.stored.host === 'selfhosted', 'DOM host signal: no probe, DOM host stored');
+
+    // Content script gone mid-probe: entry untouched, so it retries next load.
+    r = await load(seed('wpengine', now - 91 * DAY), async () => { throw new Error('no receiver'); });
+    assert(r.probed === 1 && r.stored.host === 'wpengine' && r.stored.hostCheckedAt === now - 91 * DAY,
+      'probe failure: cached badge and clock left as they were');
   }
 
   console.log(`\n${failures === 0 ? 'Background storage tests passed.' : failures + ' failure(s).'}`);

--- a/test/background-storage.js
+++ b/test/background-storage.js
@@ -869,6 +869,13 @@ async function main() {
     r = await load(seed('wpengine', now - 1 * DAY), async () => ({ host: 'kinsta' }));
     assert(r.probed === 0 && r.stored.host === 'wpengine', 'fresh cached host: no probe, badge kept');
 
+    // Eight days is past the retry clock but inside the refresh clock: a
+    // cached host must still not probe. Guards the 90-day / 7-day
+    // distinction (both clocks at seven days would probe here).
+    r = await load(seed('wpengine', now - 8 * DAY), async () => ({ host: 'kinsta' }));
+    assert(r.probed === 0 && r.stored.host === 'wpengine' && r.stored.hostCheckedAt === now - 8 * DAY,
+      'cached host between the two clocks: no probe, host and clock unchanged');
+
     // Latest probe wins: a null answer on re-validation clears the badge
     // (a site that moved to a host with no header signature).
     r = await load(seed('wpengine', now - 91 * DAY), async () => ({ host: null }));


### PR DESCRIPTION
Closes #121.

The background only ran the host header probe when no host was cached, so a badge cached wrong (a pre-#115 redirect follow, or a site that has since moved hosts) persisted indefinitely, and a probe the #115 gate rejected stored `null` and started the 90-day clock, hiding the badge for three months over a one-off redirect.

Changes, contained to `background.js` (plus the Safari mirror):

- A cached host is re-probed once `HOST_REFRESH_INTERVAL` (90 days) elapses. The probe's answer replaces the cached value, `null` included, so the badge always reflects the latest probe.
- A missing host retries on a new `HOST_RETRY_INTERVAL` (7 days) instead of the 90-day clock. Still not per page load: most self-hosted sites carry no host header at all.
- A DOM or origin host signal on the current page still wins outright with no probe, and a probe failure still leaves the entry untouched.

Test [42] in `test/background-storage.js` covers both clocks, the gap between them (an eight-day-old cached host must not probe), the DOM-signal short-circuit, and the probe-failure path. Six assertions failed against `main` before the fix.

Cosmetic only; the badge carries no security weight. Surfaced during the #115 review.
